### PR TITLE
feat: size variant for EnsAvatar and CardOffer header with wallet info

### DIFF
--- a/components/01-atoms/ENSAvatar.tsx
+++ b/components/01-atoms/ENSAvatar.tsx
@@ -12,6 +12,8 @@ enum ENSAvatarSize {
   MEDIUM = "medium",
 }
 
+type Size = ENSAvatarSize | "small" | "medium";
+
 const ENSAvatarClassName = {
   [ENSAvatarSize.SMALL]: "ens-avatar-small",
   [ENSAvatarSize.MEDIUM]: "ens-avatar-medium",
@@ -19,7 +21,7 @@ const ENSAvatarClassName = {
 
 interface ENSAvatarProps {
   avatarENSAddress: EthereumAddress;
-  size?: ENSAvatarSize;
+  size?: Size;
 }
 
 export const ENSAvatar = ({

--- a/components/01-atoms/TokenCardProperties.tsx
+++ b/components/01-atoms/TokenCardProperties.tsx
@@ -19,7 +19,7 @@ export const TokenCardProperties = ({
             {properties.value} ETH
           </p>
           <p className="dark:p-small-dark dark:!text-[#A3A9A5] p-small-variant-black">
-            &nbsp; ($){properties.value}
+            &nbsp; (${properties.value})
           </p>
         </div>
       </div>

--- a/components/02-molecules/NftCard.tsx
+++ b/components/02-molecules/NftCard.tsx
@@ -12,7 +12,7 @@ interface INftCard {
   ownerAddress: string | null;
   onClickAction?: NftCardActionType;
   withSelectionValidation?: boolean;
-  styleType?: NftCardStyleType;
+  styleType?: StyleVariant;
 }
 
 /**
@@ -31,14 +31,18 @@ export enum NftCardActionType {
 }
 
 export enum NftCardStyleType {
-  "SMALL",
-  "NORMAL",
-  "LARGE",
+  SMALL = "small",
+  NORMAL = "normal",
+  MEDIUM = "medium",
+  LARGE = "large",
 }
+
+type StyleVariant = NftCardStyleType | "small" | "normal" | "medium" | "large";
 
 const NftSizeClassNames = {
   [NftCardStyleType.SMALL]: "card-nft-small",
   [NftCardStyleType.NORMAL]: "card-nft-normal",
+  [NftCardStyleType.MEDIUM]: "card-nft-medium",
   [NftCardStyleType.LARGE]: "card-nft-large",
 };
 

--- a/components/02-molecules/UserOfferInfo.tsx
+++ b/components/02-molecules/UserOfferInfo.tsx
@@ -1,0 +1,31 @@
+import { ENSAvatar } from "@/components/01-atoms";
+import { useEnsData } from "@/lib/client/hooks/useENSData";
+import { collapseAddress } from "@/lib/client/utils";
+import { EthereumAddress } from "@/lib/shared/types";
+
+interface UserOfferInfoProps {
+  address: EthereumAddress | null;
+}
+
+export const UserOfferInfo = ({ address }: UserOfferInfoProps) => {
+  const { primaryName } = useEnsData({
+    ensAddress: address,
+  });
+  const displayAddress = collapseAddress(address?.toString() ?? "") || "";
+  return (
+    <div>
+      <div className="flex gap-2">
+        <div>
+          {address && <ENSAvatar avatarENSAddress={address} size="small" />}
+        </div>
+        <div className="flex ">
+          {primaryName ? (
+            <p>{primaryName} gets</p>
+          ) : (
+            <p>{displayAddress} gets</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/styles/global.css
+++ b/styles/global.css
@@ -22,6 +22,18 @@ input[type="search"]::-webkit-search-results-decoration {
     box-shadow: 0px 0px 6px 1px rgba(0, 0, 0, 0.3);
   }
 
+  .shadow-token {
+    box-shadow: 0px 1px 4px 1px #00000026 inset;
+  }
+
+  .shadow-tag {
+    box-shadow: 0px 0px 6px 1px #0000004d;
+  }
+
+  .shadow-three-dots {
+    box-shadow: 0px 0px 12px 1px #00000066;
+  }
+
   .title-h1 {
   }
 
@@ -101,19 +113,21 @@ input[type="search"]::-webkit-search-results-decoration {
   .p-small-dark {
     @apply font-onest font-normal text-[14px] leading-[20px] text-[#F6F6F6];
   }
-
-  .p-xsmall {
-    @apply font-onest font-normal text-[12px] leading-[20px];
+  .p-small-dark-variant-grey {
+    @apply font-onest font-normal text-[14px] leading-[20px] text-[#A3A9A5];
   }
 
   .card-nft-normal {
-    @apply shadow-inner mx-auto w-[90px] h-[90px] lg:w-[80px] lg:h-[80px] relative rounded-xl border-2 border-[#E0E0E0] bg-[#E0E0E0] dark:bg-[#353836] dark:border-[#212322] flex flex-col;
+    @apply shadow-inner mx-auto w-[90px] h-[90px] lg:w-[80px] lg:h-[80px] relative rounded-xl border-2 border-[#E0E0E0] bg-[#E0E0E0] dark:bg-[#353836] dark:border-[#212322] flex flex-col shadow-token;
   }
   .card-nft-small {
-    @apply shadow-inner mx-auto w-[44px] h-[44px] lg:w-[44px] lg:h-[44px] relative rounded-xl border-2 border-[#E0E0E0] bg-[#E0E0E0] dark:bg-[#353836] dark:border-[#212322] flex flex-col;
+    @apply shadow-inner mx-auto w-[44px] h-[44px] lg:w-[44px] lg:h-[44px] relative rounded-xl border-2 border-[#E0E0E0] bg-[#E0E0E0] dark:bg-[#353836] dark:border-[#212322] flex flex-col shadow-token;
+  }
+  .card-nft-medium {
+    @apply shadow-inner mx-auto w-[72px] h-[72px] lg:w-[72px] lg:h-[72px] relative rounded-xl border-2 border-[#E0E0E0] bg-[#E0E0E0] dark:bg-[#353836] dark:border-[#212322] flex flex-col shadow-token;
   }
   .card-nft-large {
-    @apply shadow-inner mx-auto w-[90px] h-[90px] lg:w-[80px] lg:h-[80px] relative rounded-xl border-2 border-[#E0E0E0] bg-[#E0E0E0] dark:bg-[#353836] dark:border-[#212322] flex flex-col;
+    @apply shadow-inner mx-auto w-[90px] h-[90px] lg:w-[80px] lg:h-[80px] relative rounded-xl border-2 border-[#E0E0E0] bg-[#E0E0E0] dark:bg-[#353836] dark:border-[#212322] flex flex-col shadow-token;
   }
 
   .ens-avatar-small {


### PR DESCRIPTION
- adjust some types to call the variant like size='small' or size='medium' instead call the type.
- add this component that will be present in CardOffers
![image](https://github.com/blockful-io/swaplace-dapp/assets/57544272/833b136c-13bd-42c9-9beb-a3f2e9ef471f)
