### PR TITLE
feat: token offer variant

### DIFF
--- a/components/01-atoms/NftsCardApprovedList.tsx
+++ b/components/01-atoms/NftsCardApprovedList.tsx
@@ -107,7 +107,7 @@ export const NftsCardApprovedList = () => {
 
   return (
     <div className="flex justify-center items-center relative">
-      <div className="grid grid-cols-1 w-[100%] gap-3 relative overflow-y-auto max-h-[370px]">
+      <div className="grid grid-cols-1 w-[100%] gap-3 relative overflow-y-auto max-h-[370px] no-scrollbar">
         {nftAuthUser.map((nft, index) => (
           <div
             key={index}

--- a/components/01-atoms/SwapModalLayout.tsx
+++ b/components/01-atoms/SwapModalLayout.tsx
@@ -78,13 +78,15 @@ export const SwapModalLayout = ({
                 </p>
                 <div role="button" onClick={toggleCloseButton.onClose}>
                   <CloseIcon
-                    className={cc([theme == "light" ? "text-black" : "text-white"])}
+                    className={cc([
+                      theme == "light" ? "text-black" : "text-white",
+                    ])}
                   />
                 </div>
               </Dialog.Title>
             </div>
 
-            <div className="flex flex-col gap-6 p-6 h-[460px] ">
+            <div className="flex flex-col gap-6 p-6 h-[460px] overflow-hidden">
               <div className="flex">
                 <Dialog.Description>
                   <p className="dark:p-normal-2-dark p-normal-2">

--- a/components/01-atoms/icons/SwapIcon.tsx
+++ b/components/01-atoms/icons/SwapIcon.tsx
@@ -1,7 +1,18 @@
 import { SVGProps } from "react";
 
-export const SwapIcon = (props: SVGProps<SVGSVGElement>) => {
-  return (
+export enum SwapIconVariant {
+  VERTICAL = "vertical",
+  HORIZONTAL = "horizontal",
+}
+type SwapIconVariants = SwapIconVariant | "vertical" | "horizontal";
+
+interface SwapIconProps {
+  props?: SVGProps<SVGSVGElement>;
+  variant?: SwapIconVariants;
+}
+
+export const SwapIcon = ({ props, variant = "horizontal" }: SwapIconProps) => {
+  return variant == SwapIconVariant.HORIZONTAL ? (
     <svg
       {...props}
       width="14"
@@ -55,5 +66,60 @@ export const SwapIcon = (props: SVGProps<SVGSVGElement>) => {
         </filter>
       </defs>
     </svg>
+  ) : (
+    variant == SwapIconVariant.VERTICAL && (
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g id="Swap" filter="url(#filter0_i_2167_3884)">
+          <path
+            id="Vector"
+            d="M5.10312 2.09668C4.7594 1.7506 4.20121 1.7506 3.85749 2.09668L1.21775 4.75464C0.874032 5.10073 0.874032 5.66278 1.21775 6.00887C1.56146 6.35496 2.11966 6.35496 2.46338 6.00887L3.60177 4.86262L3.60177 13.3542C3.60177 13.8443 3.99498 14.2402 4.48168 14.2402C4.96838 14.2402 5.36159 13.8443 5.36159 13.3542L5.36159 4.86262L6.49998 6.00887C6.8437 6.35496 7.40189 6.35496 7.74561 6.00887C8.08933 5.66278 8.08933 5.10073 7.74561 4.75464L5.10587 2.09668H5.10312ZM14.7822 11.3248C15.1259 10.9787 15.1259 10.4166 14.7822 10.0706C14.4385 9.72447 13.8803 9.72447 13.5365 10.0706L12.4009 11.214V2.72241C12.4009 2.23235 12.0077 1.83642 11.521 1.83642C11.0343 1.83642 10.6411 2.23235 10.6411 2.72241V11.214L9.50269 10.0678C9.15897 9.7217 8.60078 9.7217 8.25706 10.0678C7.91334 10.4139 7.91334 10.9759 8.25706 11.322L10.8968 13.98C11.2405 14.3261 11.7987 14.3261 12.1424 13.98L14.7822 11.322V11.3248Z"
+            fill="#F7F7F7"
+          />
+        </g>
+        <defs>
+          <filter
+            id="filter0_i_2167_3884"
+            x="0"
+            y="0"
+            width="16"
+            height="17"
+            filterUnits="userSpaceOnUse"
+            color-interpolation-filters="sRGB"
+          >
+            <feFlood flood-opacity="0" result="BackgroundImageFix" />
+            <feBlend
+              mode="normal"
+              in="SourceGraphic"
+              in2="BackgroundImageFix"
+              result="shape"
+            />
+            <feColorMatrix
+              in="SourceAlpha"
+              type="matrix"
+              values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+              result="hardAlpha"
+            />
+            <feOffset dy="1" />
+            <feGaussianBlur stdDeviation="1" />
+            <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+            <feColorMatrix
+              type="matrix"
+              values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.12 0"
+            />
+            <feBlend
+              mode="normal"
+              in2="shape"
+              result="effect1_innerShadow_2167_3884"
+            />
+          </filter>
+        </defs>
+      </svg>
+    )
   );
 };

--- a/components/02-molecules/CardOffers.tsx
+++ b/components/02-molecules/CardOffers.tsx
@@ -6,10 +6,10 @@ import { useContext } from "react";
 
 export enum CardOfferVariant {
   DEFAULT = "default",
-  SECUNDARY = "secundary",
+  SECONDARY = "secondary",
 }
 
-type CardOfferVariants = CardOfferVariant | "default" | "secundary";
+type CardOfferVariants = CardOfferVariant | "default" | "secondary";
 
 interface CardOffersProps {
   address: EthereumAddress | null;
@@ -62,7 +62,7 @@ export const CardOffers = ({
       <div className="md:px-4 md:pt-4 md:pb-7  ">
         <div className="flex flex-col justify-content gap-4 md:w-[400px] max-h-[150px] overflow-y-auto no-scrollbar">
           <div>
-            <UserOfferInfo address={address} variant={"secundary"} />
+            <UserOfferInfo address={address} variant={"secondary"} />
           </div>
           <div>
             {authenticatedUserAddress && ( // That div needs change to render the given Tokens by Subgraph, shouldn't be the <NftCard here/> , for now, just visualization
@@ -88,7 +88,7 @@ export const CardOffers = ({
     [CardOfferVariant.DEFAULT]: {
       body: <DefaultVariant />,
     },
-    [CardOfferVariant.SECUNDARY]: {
+    [CardOfferVariant.SECONDARY]: {
       body: <SecundaryVariant />,
     },
   };

--- a/components/02-molecules/CardOffers.tsx
+++ b/components/02-molecules/CardOffers.tsx
@@ -4,39 +4,94 @@ import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import { EthereumAddress } from "@/lib/shared/types";
 import { useContext } from "react";
 
-interface CardOffersProps {
-  address: EthereumAddress | null;
+export enum CardOfferVariant {
+  DEFAULT = "default",
+  SECUNDARY = "secundary",
 }
 
-export const CardOffers = ({ address }: CardOffersProps) => {
+type CardOfferVariants = CardOfferVariant | "default" | "secundary";
+
+interface CardOffersProps {
+  address: EthereumAddress | null;
+  variant?: CardOfferVariants;
+}
+
+interface CardOfferSConfig {
+  body: React.ReactNode;
+}
+
+export const CardOffers = ({
+  address,
+  variant = "default",
+}: CardOffersProps) => {
   const { authenticatedUserAddress } = useAuthenticatedUser();
   const { nftAuthUser } = useContext(SwapContext);
 
-  return (
-    <div className="md:p-4 ">
-      <div className="flex flex-col justify-content gap-4 md:w-[326px]">
-        <div>
-          <UserOfferInfo address={address} />
-        </div>
-        <div>
-          {authenticatedUserAddress && ( // That div needs change to render the given Tokens by Subgraph, shouldn't be the <NftCard here/> , for now, just visualization
-            <div className="grid md:grid-cols-4 md:gap-4 ">
-              {nftAuthUser.map((nft, index) => (
-                <NftCard
-                  key={index}
-                  withSelectionValidation={false}
-                  ownerAddress={authenticatedUserAddress?.address}
-                  nftData={nft}
-                  styleType="medium"
-                />
-              ))}
-            </div>
-          )}
-        </div>
-        <div>
-          <TokenCardProperties properties={{ amount: 2, value: 0.056 }} />
+  const DefaultVariant = () => {
+    return (
+      <div className="md:p-4">
+        <div className="flex flex-col justify-content gap-4 md:w-[326px]">
+          <div>
+            <UserOfferInfo address={address} />
+          </div>
+          <div>
+            {authenticatedUserAddress && ( // That div needs change to render the given Tokens by Subgraph, shouldn't be the <NftCard here/> , for now, just visualization
+              <div className="grid md:grid-cols-4 md:gap-4 ">
+                {nftAuthUser.map((nft, index) => (
+                  <NftCard
+                    key={index}
+                    withSelectionValidation={false}
+                    ownerAddress={authenticatedUserAddress?.address}
+                    nftData={nft}
+                    styleType="medium"
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+          <div>
+            <TokenCardProperties properties={{ amount: 2, value: 0.056 }} />
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
+  };
+
+  const SecundaryVariant = () => {
+    return (
+      <div className="md:px-4 md:pt-4 md:pb-7  ">
+        <div className="flex flex-col justify-content gap-4 md:w-[400px] max-h-[150px] overflow-y-auto no-scrollbar">
+          <div>
+            <UserOfferInfo address={address} variant={"secundary"} />
+          </div>
+          <div>
+            {authenticatedUserAddress && ( // That div needs change to render the given Tokens by Subgraph, shouldn't be the <NftCard here/> , for now, just visualization
+              <div className="grid md:grid-cols-5 md:gap-4 ">
+                {nftAuthUser.map((nft, index) => (
+                  <NftCard
+                    key={index}
+                    withSelectionValidation={false}
+                    ownerAddress={authenticatedUserAddress?.address}
+                    nftData={nft}
+                    styleType="medium"
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const CardOfferVariantsConfig: Record<CardOfferVariant, CardOfferSConfig> = {
+    [CardOfferVariant.DEFAULT]: {
+      body: <DefaultVariant />,
+    },
+    [CardOfferVariant.SECUNDARY]: {
+      body: <SecundaryVariant />,
+    },
+  };
+
+  return <>{CardOfferVariantsConfig[variant].body}</>;
 };

--- a/components/02-molecules/CardOffers.tsx
+++ b/components/02-molecules/CardOffers.tsx
@@ -57,7 +57,7 @@ export const CardOffers = ({
     );
   };
 
-  const SecundaryVariant = () => {
+  const SecondaryVariant = () => {
     return (
       <div className="md:px-4 md:pt-4 md:pb-7  ">
         <div className="flex flex-col justify-content gap-4 md:w-[400px] max-h-[150px] overflow-y-auto no-scrollbar">
@@ -89,7 +89,7 @@ export const CardOffers = ({
       body: <DefaultVariant />,
     },
     [CardOfferVariant.SECONDARY]: {
-      body: <SecundaryVariant />,
+      body: <SecondaryVariant />,
     },
   };
 

--- a/components/02-molecules/ConfirmSwapModal.tsx
+++ b/components/02-molecules/ConfirmSwapModal.tsx
@@ -6,7 +6,7 @@ import {
   SwapContext,
   SwapModalButton,
   SwapModalLayout,
-  OfferExpiryConfirmSwap
+  OfferExpiryConfirmSwap,
 } from "@/components/01-atoms";
 import { ProgressStatus } from "@/components/02-molecules";
 import { createSwap } from "@/lib/service/createSwap";
@@ -17,6 +17,7 @@ import {
   SwapModalSteps,
 } from "@/lib/client/blockchain-data";
 import { updateNftsToSwapApprovalStatus } from "@/lib/client/swap-utils";
+import { TokenOffers } from "@/components/03-organisms";
 import { useNetwork, useWalletClient } from "wagmi";
 import { useContext, useEffect } from "react";
 import { useTheme } from "next-themes";
@@ -174,7 +175,14 @@ export const ConfirmSwapModal = ({
           description: "Please review your final proposal.",
         }}
         body={{
-          component: <OfferExpiryConfirmSwap expireTime={"3 weeks"} />,
+          component: (
+            <>
+              <div className="flex flex-col gap-2">
+                <OfferExpiryConfirmSwap expireTime={"3 weeks"} />
+                <TokenOffers variant="vertical" />
+              </div>
+            </>
+          ),
         }}
         footer={{
           component: (
@@ -210,7 +218,14 @@ export const ConfirmSwapModal = ({
           description: "Please review your final proposal.",
         }}
         body={{
-          component: <OfferExpiryConfirmSwap expireTime={"3 weeks"} />,
+          component: (
+            <>
+              <div className="flex flex-col gap-2">
+                <OfferExpiryConfirmSwap expireTime={"3 weeks"} />
+                <TokenOffers variant="vertical" />
+              </div>
+            </>
+          ),
         }}
         footer={{
           component: (
@@ -236,7 +251,14 @@ export const ConfirmSwapModal = ({
           description: "Congrats, your swap offer was submitted.",
         }}
         body={{
-          component: <OfferExpiryConfirmSwap expireTime={"3 weeks"} />,
+          component: (
+            <>
+              <div className="flex flex-col gap-2">
+                <OfferExpiryConfirmSwap expireTime={"3 weeks"} />
+                <TokenOffers variant="vertical" />
+              </div>
+            </>
+          ),
         }}
         footer={{
           component: (

--- a/components/02-molecules/OfferSummary.tsx
+++ b/components/02-molecules/OfferSummary.tsx
@@ -59,7 +59,7 @@ export const OfferSummary = ({ forAuthedUser }: IOfferSummary) => {
         )}
       </div>
 
-      <div className="w-full h-full min-h-[144px] rounded p-4 overflow-auto max-h-52">
+      <div className="w-full h-full min-h-[144px] rounded p-4 overflow-auto max-h-52 no-scrollbar">
         <div className="w-full grid grid-cols-2 md:grid-cols-6  xl:grid-cols-4 gap-3 ">
           {(forAuthedUser && !authenticatedUserAddress?.address) ||
           (!forAuthedUser && !validatedAddressToSwap) ? null : (

--- a/components/02-molecules/UserOfferInfo.tsx
+++ b/components/02-molecules/UserOfferInfo.tsx
@@ -3,16 +3,27 @@ import { useEnsData } from "@/lib/client/hooks/useENSData";
 import { collapseAddress } from "@/lib/client/utils";
 import { EthereumAddress } from "@/lib/shared/types";
 
-interface UserOfferInfoProps {
-  address: EthereumAddress | null;
+export enum UserOfferVariant {
+  DEFAULT = "default",
+  SECUNDARY = "secundary",
 }
 
-export const UserOfferInfo = ({ address }: UserOfferInfoProps) => {
+type UserOfferVariants = UserOfferVariant | "default" | "secundary";
+
+interface UserOfferInfoProps {
+  address: EthereumAddress | null;
+  variant?: UserOfferVariants;
+}
+
+export const UserOfferInfo = ({
+  address,
+  variant = "default",
+}: UserOfferInfoProps) => {
   const { primaryName } = useEnsData({
     ensAddress: address,
   });
   const displayAddress = collapseAddress(address?.toString() ?? "") || "";
-  return (
+  return variant == UserOfferVariant.DEFAULT ? (
     <div>
       <div className="flex gap-2">
         <div>
@@ -27,5 +38,32 @@ export const UserOfferInfo = ({ address }: UserOfferInfoProps) => {
         </div>
       </div>
     </div>
+  ) : (
+    variant === UserOfferVariant.SECUNDARY && (
+      <div>
+        <div className="flex justify-between">
+          <div className="flex gap-2">
+            <div>
+              {address && <ENSAvatar avatarENSAddress={address} size="small" />}
+            </div>
+            <div className="flex ">
+              {primaryName ? (
+                <p>{primaryName} gets</p>
+              ) : (
+                <p>{displayAddress} gets</p>
+              )}
+            </div>
+          </div>
+          <div className="flex-row flex">
+            <p className="dark:p-small-dark p-small-variant-black">
+              0.1639 ETH {/* Should change to retrieve the value */}
+            </p>
+            <p className="dark:p-small-dark dark:!text-[#A3A9A5] p-small-variant-black">
+              &nbsp; ($252.15)
+            </p>
+          </div>
+        </div>
+      </div>
+    )
   );
 };

--- a/components/02-molecules/UserOfferInfo.tsx
+++ b/components/02-molecules/UserOfferInfo.tsx
@@ -5,10 +5,10 @@ import { EthereumAddress } from "@/lib/shared/types";
 
 export enum UserOfferVariant {
   DEFAULT = "default",
-  SECUNDARY = "secundary",
+  SECONDARY = "secondary",
 }
 
-type UserOfferVariants = UserOfferVariant | "default" | "secundary";
+type UserOfferVariants = UserOfferVariant | "default" | "secondary";
 
 interface UserOfferInfoProps {
   address: EthereumAddress | null;
@@ -39,7 +39,7 @@ export const UserOfferInfo = ({
       </div>
     </div>
   ) : (
-    variant === UserOfferVariant.SECUNDARY && (
+    variant === UserOfferVariant.SECONDARY && (
       <div>
         <div className="flex justify-between">
           <div className="flex gap-2">

--- a/components/03-organisms/NftsShelf.tsx
+++ b/components/03-organisms/NftsShelf.tsx
@@ -84,7 +84,7 @@ export const NftsShelf = ({ address }: INftsShelfProps) => {
   }, [validatedAddressToSwap]);
 
   return (
-    <div className="w-full  flex border-1 border-gray-200 border-t-0 rounded-2xl rounded-t-none overflow-auto bg-[#f8f8f8] dark:bg-[#212322] lg:max-w-[580px] md:h-[540px]">
+    <div className="w-full flex border-1 border-gray-200 border-t-0 rounded-2xl rounded-t-none overflow-auto bg-[#f8f8f8] dark:bg-[#212322] lg:max-w-[580px] md:h-[540px] no-scrollbar">
       {nftsQueryStatus == NFTsQueryStatus.WITH_RESULTS && nftsList ? (
         <div className="w-full h-full">
           <NftsList ownerAddress={address} nftsList={nftsList} />

--- a/components/03-organisms/TokenOffers.tsx
+++ b/components/03-organisms/TokenOffers.tsx
@@ -49,13 +49,13 @@ export const TokenOffers = ({ variant = "horizontal" }: TokenOffersProps) => {
           <div className=" border border-[#353836] rounded-lg dark:bg-[#282B29]">
             <CardOffers
               address={authenticatedUserAddress}
-              variant={"secundary"}
+              variant={"secondary"}
             />
           </div>
           <div className="border border-[#353836] rounded-lg dark:bg-[#282B29]">
             <CardOffers
               address={authenticatedUserAddress}
-              variant={"secundary"}
+              variant={"secondary"}
             />
           </div>
           <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 border border-[#707572] bg-[#212322] rounded-[100px] w-[36px] h-[36px] items-center flex justify-center">

--- a/components/03-organisms/TokenOffers.tsx
+++ b/components/03-organisms/TokenOffers.tsx
@@ -3,11 +3,26 @@ import { TokenOfferDetails, SwapIcon } from "@/components/01-atoms";
 import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import cc from "classcat";
 
-export const TokenOffers = () => {
+export enum TokenOfferVariant {
+  HORIZONTAL = "horizontal",
+  VERTICAL = "vertical",
+}
+
+type TokenOfferVariants = TokenOfferVariant | "horizontal" | "vertical";
+
+interface TokenOffersProps {
+  variant?: TokenOfferVariants;
+}
+
+interface TokenOffersConfig {
+  body: React.ReactNode;
+}
+
+export const TokenOffers = ({ variant = "horizontal" }: TokenOffersProps) => {
   const { authenticatedUserAddress } = useAuthenticatedUser();
 
-  return (
-    <>
+  const HorizontalVariant = () => {
+    return (
       <div className="flex flex-col border border-[#353836] shadow-add-manually-card dark:bg-[#282B29] rounded-lg ">
         <div className="flex flex-row border-b dark:border-[#353836] relative">
           <div className={cc(["border-r dark:border-[#353836] "])}>
@@ -24,6 +39,41 @@ export const TokenOffers = () => {
           <TokenOfferDetails />
         </div>
       </div>
-    </>
-  );
+    );
+  };
+
+  const VerticalVariant = () => {
+    return (
+      <div className="flex flex-col rounded-lg ">
+        <div className="flex flex-col relative gap-2">
+          <div className=" border border-[#353836] rounded-lg dark:bg-[#282B29]">
+            <CardOffers
+              address={authenticatedUserAddress}
+              variant={"secundary"}
+            />
+          </div>
+          <div className="border border-[#353836] rounded-lg dark:bg-[#282B29]">
+            <CardOffers
+              address={authenticatedUserAddress}
+              variant={"secundary"}
+            />
+          </div>
+          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 border border-[#707572] bg-[#212322] rounded-[100px] w-[36px] h-[36px] items-center flex justify-center">
+            <SwapIcon variant={"vertical"} />
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const TokenOffersPropsConfig: Record<TokenOfferVariant, TokenOffersConfig> = {
+    [TokenOfferVariant.HORIZONTAL]: {
+      body: <HorizontalVariant />,
+    },
+    [TokenOfferVariant.VERTICAL]: {
+      body: <VerticalVariant />,
+    },
+  };
+
+  return <>{TokenOffersPropsConfig[variant].body}</>;
 };

--- a/styles/global.css
+++ b/styles/global.css
@@ -15,6 +15,17 @@ input[type="search"]::-webkit-search-results-decoration {
 @tailwind utilities;
 
 @layer utilities {
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Hide scrollbar for IE, Edge and Firefox */
+  .no-scrollbar {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+  }
+
   .shadow-add-manually-card {
     box-shadow: 0px 0px 12px 1px #00000066;
   }


### PR DESCRIPTION
Closes #46
- create variant 'horizontal' & 'vertical' in TokenOffers
- create variant 'default' & 'secondary' in UserOfferInfo
- create variant 'horizontal' & 'vertical' in SwapIcon
- create variant 'default' & 'secondary' in CardOffers
- adjust the size of the organism TokenOffer inside the SwapModal 
- remove the scrollbars from the entire dApp

The variants created reduced the creation of new atoms by half. 
The body of TokenOffers should be changed to render the Tokens by Subgraph queries :) For now, just visualization of NftCards.