### PR TITLE
feat: added SearchItemsShelf atom to be the search bar for  the SwappingShelfs organism

### DIFF
--- a/components/01-atoms/SearchItemsShelf.tsx
+++ b/components/01-atoms/SearchItemsShelf.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlassIcon } from "@/components/01-atoms/icons/MagnifyingGlassIcon";
+import { MagnifyingGlassIcon } from "@/components/01-atoms";
 import { useTheme } from "next-themes";
 import cc from "classcat";
 
@@ -12,7 +12,7 @@ export const SearchItemsShelf = () => {
         name="search"
         type="search"
         className={cc([
-          "flex items-center pl-9 rounded-lg h-8 gap-3 font-normal leading-5 text-sm not-italic placeholder-[#707572] border border-[#353836] opacity-80 bg-[#282B29] transition duration-300 ease-in-out focus:outline-none",
+          "flex items-center pl-9 rounded-lg max-w-[216px] h-8 gap-3 font-normal leading-5 text-sm not-italic placeholder-[#707572] border border-[#353836] opacity-80 bg-[#282B29] transition duration-300 ease-in-out focus:outline-none",
           theme == "light"
             ? "bg-[#F6F6F6] hover:bg-[#F0EEEE] border-[#E4E4E4] hover:border-[#D6D5D5] focus:border-[#AABE13] hover:shadow-[0_0_6px_1px_#00000014] focus:shadow-[0_0_6px_1px_#00000014] focus:border-opacity-100"
             : "hover:dark:bg-[#353836] hover:dark:border-[#505150] hover:dark:shadow-[0_0_6px_1px_#00000066] focus:dark:shadow-[0_0_6px_1px_#00000066] focus:dark:border-[#AABE13]",

--- a/components/01-atoms/SearchItemsShelf.tsx
+++ b/components/01-atoms/SearchItemsShelf.tsx
@@ -1,0 +1,32 @@
+import { MagnifyingGlassIcon } from "@/components/01-atoms/icons/MagnifyingGlassIcon";
+import { useTheme } from "next-themes";
+import cc from "classcat";
+
+export const SearchItemsShelf = () => {
+  const { theme } = useTheme();
+
+  return (
+    <div className="relative flex-grow">
+      <input
+        id="search"
+        name="search"
+        type="search"
+        className={cc([
+          "flex items-center pl-9 rounded-lg h-8 gap-3 font-normal leading-5 text-sm not-italic placeholder-[#707572] border border-[#353836] opacity-80 bg-[#282B29] transition duration-300 ease-in-out focus:outline-none",
+          theme == "light"
+            ? "bg-[#F6F6F6] hover:bg-[#F0EEEE] border-[#E4E4E4] hover:border-[#D6D5D5] focus:border-[#AABE13] hover:shadow-[0_0_6px_1px_#00000014] focus:shadow-[0_0_6px_1px_#00000014] focus:border-opacity-100"
+            : "hover:dark:bg-[#353836] hover:dark:border-[#505150] hover:dark:shadow-[0_0_6px_1px_#00000066] focus:dark:shadow-[0_0_6px_1px_#00000066] focus:dark:border-[#AABE13]",
+        ])}
+        placeholder="Search for items"
+        aria-label="Search"
+        aria-describedby="button-addon2"
+      />
+      <div className="absolute inset-y-0 left-0 flex items-center pl-3">
+        <MagnifyingGlassIcon
+          className="w-4"
+          fill={cc([theme == "light" ? "#E4E4E4" : "#353836"])}
+        />
+      </div>
+    </div>
+  );
+};

--- a/components/01-atoms/Tab.tsx
+++ b/components/01-atoms/Tab.tsx
@@ -30,7 +30,7 @@ export const Tab = ({ setActiveSwappingShelfID }: ITab) => {
   const [isActiveTab, setIsActiveTab] = useState(SwappingShelfID.THEIR_ITEMS);
 
   return (
-    <div className="w-full font-light flex-auto flex items-center justify-between  overflow-hidden  ">
+    <div className="w-full font-light flex-auto flex items-center justify-between  overflow-hidden ">
       {swappingTabs.map((tab) => {
         return (
           <div
@@ -39,7 +39,7 @@ export const Tab = ({ setActiveSwappingShelfID }: ITab) => {
               isActiveTab == tab.id
                 ? "dark:p-medium-bold-dark p-medium-bold border-b dark:border-[#DDF23D] border-black "
                 : "dark:p-medium-bold p-medium-bold opacity-50 border-b dark:border-[#313131]",
-              "flex-1 p-4  cursor-pointer",
+              "flex cursor-pointer py-4 px-5",
             ])}
             role="tab"
             onClick={() => {
@@ -47,7 +47,9 @@ export const Tab = ({ setActiveSwappingShelfID }: ITab) => {
               setIsActiveTab(tab.id);
             }}
           >
-            <div className="flex items-center justify-center">{tab.name}</div>
+            <div className="flex items-center justify-center w-[74px] h-[16px]">
+              {tab.name}
+            </div>
           </div>
         );
       })}

--- a/components/01-atoms/index.ts
+++ b/components/01-atoms/index.ts
@@ -7,6 +7,7 @@ export * from "./OfferTag";
 export * from "./NftsCardApprovedList";
 export * from "./ProgressBar";
 export * from "./SearchBar";
+export * from "./SearchItemsShelf";
 export * from "./SelectAuthedUserChain";
 export * from "./SelectDestinyChain";
 export * from "./StatusOffers";

--- a/components/03-organisms/SwappingShelfs.tsx
+++ b/components/03-organisms/SwappingShelfs.tsx
@@ -1,6 +1,11 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { NftsShelf } from "@/components/03-organisms";
-import { SwapContext, SwappingShelfID, Tab } from "@/components/01-atoms/";
+import {
+  SwapContext,
+  SwappingShelfID,
+  SearchItemsShelf,
+  Tab,
+} from "@/components/01-atoms/";
 import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import { useContext, useEffect, useState } from "react";
 import { useNetwork } from "wagmi";
@@ -34,9 +39,18 @@ export const SwappingShelfs = () => {
 
   return (
     <div className="w-[95%] mb-20 dark:bg-[#212322] dark:border-[#353836] border rounded-2xl ">
-      <Tab
-        setActiveSwappingShelfID={(input) => setActiveSwappingShelfID(input)}
-      />
+      <div className="flex items-center justify-between max-h-[48px]">
+        <div className="flex max-w-[224px]">
+          <Tab
+            setActiveSwappingShelfID={(input) =>
+              setActiveSwappingShelfID(input)
+            }
+          />
+        </div>
+        <div className="pr-2">
+          <SearchItemsShelf />
+        </div>
+      </div>
       <div className={cc([activeSwappingShelfID ? "hidden" : "block"])}>
         <NftsShelf address={validatedAddressToSwap} variant="their" />
       </div>


### PR DESCRIPTION
closes #45 

- [x] Create the proposed atom for SwappingShelfs.
- [x] Dark/Light mode
- [x] Check the style of the 3 States( DEFAULT, HOVER, PRESSING )


I've created the atom `searchItemsShelf` to be a search bar for the `SwappingShelfs.tsx` organism.

It has no function to search yet, it's just the model.

DARK MODE
![image](https://github.com/blockful-io/swaplace-dapp/assets/102108966/ec4220e2-cc98-420e-a6ce-7d2e6ead6676)
![image](https://github.com/blockful-io/swaplace-dapp/assets/102108966/d1557cbd-a29a-4794-8814-50b474cf2f97)
![image](https://github.com/blockful-io/swaplace-dapp/assets/102108966/a1de6cde-e827-46c6-9a06-2446d230c789)
![image](https://github.com/blockful-io/swaplace-dapp/assets/102108966/ab1611cc-520f-4efc-adf2-2a071f537405)

LIGHT MODE
![image](https://github.com/blockful-io/swaplace-dapp/assets/102108966/376e19d9-8464-4386-8321-d9bf99275125)
![image](https://github.com/blockful-io/swaplace-dapp/assets/102108966/c2fa7929-3e5b-430c-889c-f2457a8c6636)
![image](https://github.com/blockful-io/swaplace-dapp/assets/102108966/3fa7256a-e701-445b-878e-5f311f86a843)
![image](https://github.com/blockful-io/swaplace-dapp/assets/102108966/daf09419-f929-430b-b90f-7191800c0c8c)
