### PR TITLE
fix: grid not showing in swap confirmation modal

### DIFF
--- a/components/01-atoms/SwapModalLayout.tsx
+++ b/components/01-atoms/SwapModalLayout.tsx
@@ -74,7 +74,7 @@ export const SwapModalLayout = ({
               </Dialog.Title>
             </div>
 
-            <div className="flex flex-col gap-6 p-6 overflow-hidden">
+            <div className="flex flex-col gap-6 p-6 no-scrollbar overflow-x-hidden overflow-y-auto">
               {text.description && (
                 <div className="flex dark:p-normal-2-dark p-normal-2">
                   <Dialog.Description>{text.description}</Dialog.Description>

--- a/components/01-atoms/TokenCardsPlaceholder.tsx
+++ b/components/01-atoms/TokenCardsPlaceholder.tsx
@@ -11,15 +11,19 @@ interface TokenCardsPlaceholderProps {
   desktopTotalSquares?: number;
   tabletTotalSquares?: number;
   mobileTotalSquares?: number;
+  confirmationModalTotalSquares?: number;
   styleType?: TokenCardStyleType;
 }
 
+/// @dev Some shelfs will have more lines than others, even it's line is fully empty, preserving the design aspects.
+/// And other shelfs will have single lines. But both of the mentioned cases will work while scaling the grid to handle more items.
 export const TokenCardsPlaceholder = ({
   totalCardsLength,
   wideScreenTotalSquares = 24,
   desktopTotalSquares = 24,
   tabletTotalSquares = 24,
   mobileTotalSquares = 15,
+  confirmationModalTotalSquares = 0, // 0 for turning off as default, 1 or more for total squares
   styleType = TokenCardStyleType.MEDIUM,
 }: TokenCardsPlaceholderProps) => {
   const { isDesktop, isTablet, isWideScreen, isMobile } = useScreenSize();
@@ -27,28 +31,42 @@ export const TokenCardsPlaceholder = ({
   let totalSquares = 0;
   let totalSquaresX = 0; // Token quantity in X axis
 
-  // We are getting X count as the LCM to fill the rows with empty cards correctly.
-  isMobile
-    ? ((totalSquares = mobileTotalSquares),
+  // !IMPORTANT: We assume the values passed as arguments are defined in the design and using random values might break
+  // Confirmation modal will always have 1 row in the grid with the amount of columns passed
+  // on `confirmationModalTotalSquares` and expand if needed respecting the max columns given.
+  confirmationModalTotalSquares > 0
+    ? ((totalSquares = confirmationModalTotalSquares),
+      (totalSquaresX = confirmationModalTotalSquares))
+    : isMobile
+    ? // For the rest of the cases, we need to have a determined amount of rows and columns to fill the design.
+      // The LCM (Least Common Multiple) is used to find the common multiple to determine the amount of empty squares needed.
+      ((totalSquares = mobileTotalSquares),
+      // If the totalSquares matches the hardcoded maxium amount of columns, we set total squares on the X axis to the LCM
+      // hardcoded value. Otherwise, we set the default total squares on the X axis to 6 for all screen sizes and 3 for mobile.
+      // We have to do this approachbecause the `OfferSummar.tsx` component has an specific design that don't match the others.
       mobileTotalSquares == 5 ? (totalSquaresX = 5) : (totalSquaresX = 3))
     : isWideScreen
     ? ((totalSquares = wideScreenTotalSquares),
       wideScreenTotalSquares == 10 ? (totalSquaresX = 5) : (totalSquaresX = 6))
     : isDesktop
     ? ((totalSquares = desktopTotalSquares),
-      desktopTotalSquares == 8 ? (totalSquaresX = 4) : (totalSquaresX = 6))
+      desktopTotalSquares == 6 ? (totalSquaresX = 3) : (totalSquaresX = 3))
     : isTablet &&
       ((totalSquares = tabletTotalSquares),
       tabletTotalSquares == 10 ? (totalSquaresX = 5) : (totalSquaresX = 6));
 
+  // We calculate the the modulus to determine the amount of empty squares needed to fill the squares on the X axis.
   const spareTokensX = totalCardsLength % totalSquaresX;
+  // If the modulus is 0 we don't need to add empty squares to the grid.
+  // If the modulus is different than 0, the `emptySquaresCountX` will take the value of the empty squares needed to fill the row.
   const emptySquaresCountX = spareTokensX ? totalSquaresX - spareTokensX : 0;
-
+  // We calculate the total amount of empty squares needed to fill the entire grid.
   const spareTokens = totalSquares - totalCardsLength;
+  // If the total amount of empty squares needed to fill the row is less than the amount of empty squares needed to fill the grid,
+  // we set the `emptySquaresCount` to the amount of empty squares needed to fill the grid. Otherwise, we set the `emptySquaresCount`
+  // to the total amount of empty squares needed to fill row.
   const emptySquaresCount =
-    emptySquaresCountX < spareTokens
-      ? Math.max(spareTokens, 0)
-      : emptySquaresCountX;
+    emptySquaresCountX < spareTokens ? spareTokens : emptySquaresCountX;
 
   return Array.from({ length: emptySquaresCount }, (_, index) => (
     <>

--- a/components/02-molecules/CardOffers.tsx
+++ b/components/02-molecules/CardOffers.tsx
@@ -68,19 +68,20 @@ export const CardOffers = ({
     if (!address) return null;
 
     return (
-      <div className="flex flex-col justify-content gap-4 md:w-[400px] max-h-[150px] overflow-y-auto no-scrollbar">
+      <div className="flex flex-col justify-content gap-4 md:w-[400px] overflow-x-hidden no-scrollbar">
         <UserOfferInfo address={address} variant={UserOfferVariant.SECONDARY} />
         <TokensList
           ownerAddress={address}
           withAddTokenCard={false}
-          withPlaceholders={false}
+          withPlaceholders={true}
           variant={tokenShelfVariant}
           displayERC20TokensAmount={true}
           withSelectionValidation={false}
           tokenCardClickAction={TokenCardActionType.NO_ACTION}
           tokensList={tokensOfferFor[tokenShelfVariant]}
+          confirmationModalTotalSquares={5}
           tokenCardStyleType={TokenCardStyleType.MEDIUM}
-          gridClassNames="grid md:grid-cols-5 md:gap-4"
+          gridClassNames="grid md:grid-cols-5 md:gap-3"
         />
       </div>
     );

--- a/components/02-molecules/OfferSummary.tsx
+++ b/components/02-molecules/OfferSummary.tsx
@@ -93,7 +93,7 @@ export const OfferSummary = ({ variant }: IOfferSummary) => {
             </div>
           )}
         </div>
-        <div className="w-full h-full max-h-[156px] rounded overflow-auto no-scrollbar">
+        <div className="w-full h-full max-h-[156px] rounded overflow-x-hidden overflow-y-auto no-scrollbar">
           {variant === TokensShelfVariant.Your && authenticatedUserAddress ? (
             <TokensList
               withAddTokenCard={false}
@@ -103,11 +103,11 @@ export const OfferSummary = ({ variant }: IOfferSummary) => {
               tokensList={tokensList}
               variant={variant}
               wideScreenTotalCards={10}
-              desktopTotalCards={8}
+              desktopTotalCards={6}
               tabletTotalCards={12}
               mobileTotalCards={6}
               tokenCardStyleType={TokenCardStyleType.MEDIUM}
-              gridClassNames="w-full grid grid-cols-3 md:grid-cols-6 xl:grid-cols-5 lg:grid-cols-4 gap-3"
+              gridClassNames="w-full grid grid-cols-3 md:grid-cols-6 xl:grid-cols-5 lg:grid-cols-3 gap-2 md:gap-3 xl:gap-3 lg:gap-3"
             />
           ) : variant === TokensShelfVariant.Their && validatedAddressToSwap ? (
             <TokensList
@@ -118,11 +118,11 @@ export const OfferSummary = ({ variant }: IOfferSummary) => {
               tokensList={tokensList}
               variant={variant}
               wideScreenTotalCards={10}
-              desktopTotalCards={8}
+              desktopTotalCards={6}
               tabletTotalCards={12}
               mobileTotalCards={6}
               tokenCardStyleType={TokenCardStyleType.MEDIUM}
-              gridClassNames="w-full grid grid-cols-3 md:grid-cols-6 xl:grid-cols-5 lg:grid-cols-4 gap-3"
+              gridClassNames="w-full grid grid-cols-3 md:grid-cols-6 xl:grid-cols-5 lg:grid-cols-3 gap-2 md:gap-3 xl:gap-3 lg:gap-3"
             />
           ) : (
             <TokensList
@@ -133,11 +133,11 @@ export const OfferSummary = ({ variant }: IOfferSummary) => {
               tokensList={tokensList}
               variant={variant}
               wideScreenTotalCards={10}
-              desktopTotalCards={8}
+              desktopTotalCards={6}
               tabletTotalCards={12}
               mobileTotalCards={6}
               tokenCardStyleType={TokenCardStyleType.MEDIUM}
-              gridClassNames="w-full grid grid-cols-3 md:grid-cols-6 xl:grid-cols-5 lg:grid-cols-4 gap-3"
+              gridClassNames="w-full grid grid-cols-3 md:grid-cols-6 xl:grid-cols-5 lg:grid-cols-3 gap-2 md:gap-3 xl:gap-3 lg:gap-3"
             />
           )}
         </div>

--- a/components/02-molecules/TokensList.tsx
+++ b/components/02-molecules/TokensList.tsx
@@ -97,8 +97,8 @@ export const TokensList = ({
       })
     : [<></>];
   const tokenCards = tokensList.map((token: Token, index) => (
-    <div key={`token-${index}`}>
       <TokenCard
+        key={index}
         styleType={tokenCardStyleType}
         onClickAction={tokenCardClickAction}
         displayERC20TokensAmount={displayERC20TokensAmount}
@@ -107,7 +107,6 @@ export const TokensList = ({
         ownerAddress={ownerAddress}
         tokenData={token}
       />
-    </div>
   ));
 
   let allSquares = [...tokenCards, ...placeholders];

--- a/components/02-molecules/TokensList.tsx
+++ b/components/02-molecules/TokensList.tsx
@@ -21,6 +21,7 @@ export interface TokensListProps {
   tabletTotalCards?: number;
   desktopTotalCards?: number;
   wideScreenTotalCards?: number;
+  confirmationModalTotalSquares?: number;
 
   /* 
     When true, instead of displaying an ERC20 Token balance
@@ -51,6 +52,7 @@ export const TokensList = ({
   tabletTotalCards,
   desktopTotalCards,
   wideScreenTotalCards,
+  confirmationModalTotalSquares = 0,
   withPlaceholders = true,
   withAddTokenCard = true,
   withSelectionValidation = true,
@@ -90,6 +92,7 @@ export const TokensList = ({
         tabletTotalSquares: tabletTotalCards,
         desktopTotalSquares: desktopTotalCards,
         wideScreenTotalSquares: wideScreenTotalCards,
+        confirmationModalTotalSquares: confirmationModalTotalSquares,
         styleType: tokenCardStyleType,
       })
     : [<></>];


### PR DESCRIPTION
## Bug Fixes

TL;DR
- Fixed missing grid on swap confirmation modal
- Fixed grid glitches regarding overflow(scrolling)
- Commented on empty cards logic for the grids

Changes:
- added the grid sizes to the card
- added a new type called `isConfirmationModal` for confirmations when creating swaps in the swap station and when confirming accept swaps in swap offers. This boolean will define a single line of 5 squares
- changed the laptop/desktop squares from 4 to 3. They were being overflowed/cutted from the frame
- commented the entire placeholder code/logic
- removed unnecessary Math when calculating emptySquaresCount
- fixed overflows on offerSummary, hidden for X and auto for Y
- fixed gap for mobile-s (was cutting out of the frame)
- removed the scroll from the grids in all the offerSummary