### PR TITLE
fix: forcing refresh of `offersFilter`

### DIFF
--- a/components/01-atoms/OffersContext.tsx
+++ b/components/01-atoms/OffersContext.tsx
@@ -254,7 +254,7 @@ export const OffersContextProvider = ({ children }: any) => {
   };
 
   // Offers query
-  const { data, status, isFetchingNextPage, fetchNextPage, isError } =
+  const { data, status, isFetchingNextPage, fetchNextPage, isError, refetch } =
     useInfiniteQuery({
       queryKey: ["PonderQuerySwaps", authenticatedUserAddress, offersFilter],
       queryFn: async ({ pageParam }: { pageParam: string | null }) =>
@@ -265,6 +265,10 @@ export const OffersContextProvider = ({ children }: any) => {
       getNextPageParam: (lastPage) => lastPage?.pageInfo?.endCursor,
       enabled: !!authenticatedUserAddress,
     });
+
+  useEffect(() => {
+    refetch();
+  }, [offersFilter, refetch]);
 
   const [hasNextPage, setHasNextPage] = useState(false);
 


### PR DESCRIPTION
The `offersFilter` was not refreshing the data on the filters that were already fetched, meaning that when clicked twice in the same filter, the data would not be refreshed.

Now they are refreshing regardless how many times ou click on the filter.

closes #322 