### PR TITLE
Refactor: Make Offers be displayed according to the network

### DIFF
--- a/lib/client/contexts/OffersContext.tsx
+++ b/lib/client/contexts/OffersContext.tsx
@@ -21,14 +21,13 @@ import {
   RawSwapOfferInterface,
   PageInfo,
 } from "@/lib/client/offers-utils";
+import { SwapContext } from "@/lib/client/contexts";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import React, { Dispatch, useEffect, useState, useContext } from "react";
 import axios from "axios";
 import { isAddress } from "viem";
-import { useAccount } from "wagmi";
+import { useAccount, useNetwork } from "wagmi";
 import toast from "react-hot-toast";
-import { SwapContext } from "@/lib/client/contexts";
-import { useNetwork } from "wagmi";
 
 export enum PonderFilter {
   ALL_OFFERS = "All Offers",

--- a/lib/client/offer-queries.ts
+++ b/lib/client/offer-queries.ts
@@ -1,10 +1,10 @@
 //Recipient and value added to each query
 export const ALL_OFFERS_QUERY = `
-         query swapDatabases($orderBy: String!, $orderDirection: String!, $inputAddress: String, $after: String, $allowed: String) {
+         query swapDatabases($orderBy: String!, $orderDirection: String!, $inputAddress: String, $after: String, $allowed: String, $network: BigInt ) {
           swapDatabases(
              orderBy: $orderBy,
              orderDirection: $orderDirection,
-             where: { OR: [{owner: $inputAddress}, {allowed: $allowed}] },
+             where: { AND: [{network: $network}, {OR: [{owner: $inputAddress}, {allowed: $allowed}]}]},
              limit: 20,
              after: $after
            ) {
@@ -29,11 +29,11 @@ export const ALL_OFFERS_QUERY = `
          }
        `;
 export const CREATED_OFFERS_QUERY = `
-         query swapDatabases($orderBy: String!, $orderDirection: String!, $inputAddress: String, $after: String, $expiry_gt: BigInt) {
+         query swapDatabases($orderBy: String!, $orderDirection: String!, $inputAddress: String, $after: String, $expiry_gt: BigInt, $network: BigInt ) {
           swapDatabases(
              orderBy: $orderBy,
              orderDirection: $orderDirection,
-             where: { owner: $inputAddress, status: CREATED, expiry_gt: $expiry_gt },
+             where: { owner: $inputAddress, status: CREATED, expiry_gt: $expiry_gt, network: $network },
              limit: 20,
              after: $after
            ) {
@@ -59,11 +59,11 @@ export const CREATED_OFFERS_QUERY = `
        `;
 
 export const RECEIVED_OFFERS_QUERY = `
-         query swapDatabases($orderBy: String!, $orderDirection: String!, $after: String, $allowed: String, $expiry_gt: BigInt) {
+         query swapDatabases($orderBy: String!, $orderDirection: String!, $after: String, $allowed: String, $expiry_gt: BigInt, $network: BigInt) {
           swapDatabases(
              orderBy: $orderBy,
              orderDirection: $orderDirection,
-             where: { allowed: $allowed, status_not: ACCEPTED, expiry_gt: $expiry_gt },
+             where: { allowed: $allowed, status_not: ACCEPTED, expiry_gt: $expiry_gt, network: $network },
              limit: 20,
              after: $after
            ) {
@@ -89,11 +89,11 @@ export const RECEIVED_OFFERS_QUERY = `
        `;
 
 export const ACCEPTED_OFFERS_QUERY = `
-         query swapDatabases($orderBy: String!, $orderDirection: String!, $inputAddress: String, $after: String, $allowed: String) {
+         query swapDatabases($orderBy: String!, $orderDirection: String!, $inputAddress: String, $after: String, $allowed: String, $network: BigInt) {
           swapDatabases(
              orderBy: $orderBy,
              orderDirection: $orderDirection,
-             where: { AND: [ {status: ACCEPTED}, {OR: [ {owner: $inputAddress},{allowed: $allowed}]}]},
+             where: { AND: [ {status: ACCEPTED}, {network: $network}, {OR: [ {owner: $inputAddress},{allowed: $allowed}]}]},
              limit: 20,
              after: $after
            ) {
@@ -119,11 +119,11 @@ export const ACCEPTED_OFFERS_QUERY = `
        `;
 
 export const CANCELED_OFFERS_QUERY = `
-         query swapDatabases($orderBy: String!, $orderDirection: String!, $inputAddress: String, $after: String, $allowed: String) {
+         query swapDatabases($orderBy: String!, $orderDirection: String!, $inputAddress: String, $after: String, $allowed: String, $network: BigInt) {
           swapDatabases(
              orderBy: $orderBy,
              orderDirection: $orderDirection,
-             where: { AND: [ {status: CANCELED}, {OR: [ {owner: $inputAddress}, {allowed: $allowed}]}]},
+             where: { AND: [ {status: CANCELED}, {network: $network}, {OR: [ {owner: $inputAddress}, {allowed: $allowed}]}]},
              limit: 20,
              after: $after
            ) {
@@ -149,23 +149,12 @@ export const CANCELED_OFFERS_QUERY = `
        `;
 
 export const EXPIRED_OFFERS_QUERY = `
-         query swapDatabases($orderBy: String!, $orderDirection: String!, $inputAddress: String, $after: String, $expiry_lt: BigInt) {
+         query swapDatabases($orderBy: String!, $orderDirection: String!, $inputAddress: String, $after: String, $expiry_lt: BigInt, $network: BigInt, $allowed: String,) {
           swapDatabases(
              orderBy: $orderBy,
              orderDirection: $orderDirection,
-             where: {
-              AND: [
-                {
-                  OR: [
-                    { owner: $inputAddress },
-                    { allowed: $inputAddress }
-                  ]
-                },
-                { status_not: ACCEPTED },
-                { status_not: CANCELED },
-                { expiry_lt: $expiry_lt }
-              ]
-            },
+             where: { AND: [{ status_not: ACCEPTED }, { status_not: CANCELED }, { expiry_lt: $expiry_lt }, {network: $network}, 
+              {OR: [{ owner: $inputAddress }, { allowed: $allowed}]}]},
              limit: 20,
              after: $after
            ) {


### PR DESCRIPTION
closes #346 

When changing networks the according events should be fetched and displayed due to the:

- [x] Changes in queries, added the `network` property to filter by network
- [x] Dynamic network added to the `variables` of the queries

this issue is related to the issue in the backend [#38](https://github.com/blockful-io/swaplace-subgraph/issues/38) 