### PR TITLE
fix: Specific toast error message

### DIFF
--- a/lib/client/blockchain-utils.ts
+++ b/lib/client/blockchain-utils.ts
@@ -284,6 +284,8 @@ export const toastBlockchainTxError = (e: string) => {
     toast.error("Transaction rejected");
   } else if (e.includes("InvalidExpiry")) {
     toast.error("Select a valid date to your swap.");
+  } else if (e.includes("approve caller is not token owner")) {
+    toast.error("You are not the owner of this token");
   } else {
     toast.error("Transaction failed. Please contact our team");
   }


### PR DESCRIPTION
New toast error message for when the user try to approve a token who they are not the owner

![image](https://github.com/blockful-io/swaplace-dapp/assets/102108966/144573e6-6df8-4d78-9448-15f079970e52)

closes #352 