### PR TITLE
fix: Display empty swap page when swaps are empty

### DIFF
--- a/components/03-organisms/SwapOffers.tsx
+++ b/components/03-organisms/SwapOffers.tsx
@@ -29,7 +29,6 @@ import cc from "classcat";
 export const SwapOffers = () => {
   const { hasNextPage, fetchNextPage, isFetchingNextPage, isError, data } =
     useContext(OffersContext);
-  const { tokensList } = useContext(OffersContext);
   const [toggleManually, setToggleManually] = useState<boolean>(false);
   const { authenticatedUserAddress } = useAuthenticatedUser();
 
@@ -56,9 +55,10 @@ export const SwapOffers = () => {
         <TokensOfferSkeleton />
       </div>
     </div>
-  ) : isError && tokensList.length === 0 ? (
+  ) : isError && data.every((page) => page.swapOffers.length === 0) ? (
     <SwapOffersLayout variant={SwapOffersDisplayVariant.ERROR} />
-  ) : tokensList.length === 0 || !authenticatedUserAddress ? (
+  ) : data.every((page) => page.swapOffers.length === 0) ||
+    !authenticatedUserAddress ? (
     <SwapOffersLayout variant={SwapOffersDisplayVariant.NO_SWAPS_CREATED} />
   ) : (
     data && (


### PR DESCRIPTION
Corrected bug where the page of `No swaps here. Let's fill it up` was not being displayed for empty swaps lists.

Changed the `tokensList.lenght === 0` to use the new `data` instead

closes #358 