### PR TITLE
feat: debouncing in `offerQueries`

### DIFF
--- a/lib/client/hooks/useDebounce.ts
+++ b/lib/client/hooks/useDebounce.ts
@@ -1,10 +1,10 @@
 import { PonderFilter } from "@/lib/client/contexts/OffersContext";
-import React from "react";
+import { useEffect, useState } from "react";
 
 export default function useDebounce(value: PonderFilter, delay = 500) {
-  const [debouncedValue, setDebouncedValue] = React.useState(value);
+  const [debouncedValue, setDebouncedValue] = useState<PonderFilter>(value);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const handler: NodeJS.Timeout = setTimeout(() => {
       setDebouncedValue(value);
     }, delay);

--- a/lib/client/hooks/useDebounce.ts
+++ b/lib/client/hooks/useDebounce.ts
@@ -1,0 +1,19 @@
+import { PonderFilter } from "@/lib/client/contexts/OffersContext";
+import React from "react";
+
+export default function useDebounce(value: PonderFilter, delay = 500) {
+  const [debouncedValue, setDebouncedValue] = React.useState(value);
+
+  React.useEffect(() => {
+    const handler: NodeJS.Timeout = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Cancel the timeout if value changes (also on delay change or unmount)
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
closes #376 

Added a debouncing feature to work with the `offerQueries` so it lowers the API calls rate when users are changing filters in the `Offers` page