### PR TITLE
refactor: getOwner to getAddress

### DIFF
--- a/components/01-atoms/SearchBar.tsx
+++ b/components/01-atoms/SearchBar.tsx
@@ -21,7 +21,6 @@ export const SearchBar = () => {
     process.env.NEXT_PUBLIC_ALCHEMY_ETHEREUM_HTTP,
   );
   const ens = new ENS(undefined, provider);
-  console.log("SearchBar -> ens", ens);
 
   const {
     lastWalletConnected,
@@ -76,9 +75,7 @@ export const SearchBar = () => {
       const formattedAddress = normalizeENSName(inputAddress);
 
       try {
-        console.log("getUserAddress -> formattedAddress", formattedAddress);
         const address: unknown = await ens.getAddress(formattedAddress);
-        console.log("getUserAddress -> address", address);
         if (typeof address !== "string") {
           toast.error(
             "Wrong type of address returned by provider. Please contact the team",

--- a/components/01-atoms/SearchBar.tsx
+++ b/components/01-atoms/SearchBar.tsx
@@ -21,6 +21,7 @@ export const SearchBar = () => {
     process.env.NEXT_PUBLIC_ALCHEMY_ETHEREUM_HTTP,
   );
   const ens = new ENS(undefined, provider);
+  console.log("SearchBar -> ens", ens);
 
   const {
     lastWalletConnected,
@@ -75,7 +76,9 @@ export const SearchBar = () => {
       const formattedAddress = normalizeENSName(inputAddress);
 
       try {
-        const address: unknown = await ens.getOwner(formattedAddress);
+        console.log("getUserAddress -> formattedAddress", formattedAddress);
+        const address: unknown = await ens.getAddress(formattedAddress);
+        console.log("getUserAddress -> address", address);
         if (typeof address !== "string") {
           toast.error(
             "Wrong type of address returned by provider. Please contact the team",


### PR DESCRIPTION
Closes #320 

- With getAddress we can retrieve the actual address searched ( per example: 0xneves )
<img width="476" alt="image" src="https://github.com/blockful-io/swaplace-dapp/assets/57544272/c9a20a1e-1d6f-4741-b42f-5051fda874ad">


GetAddress & GetOwner differences:

	/**
	 * Returns the owner by the given name and current configured or detected Registry
	 * @param name - The ENS name
	 * @returns - Returns the address of the owner of the name.
	 * @example
	 * ```ts
	 * const owner = await web3.eth.ens.getOwner('ethereum.eth');
	 * ```
	 */
	public async getOwner(name: string): Promise<unknown> {
		return this._registry.getOwner(name);
	}

	/**
	 * Resolves an ENS name to an Ethereum address.
	 * @param ENSName - The ENS name to resolve
	 * @param coinType - (Optional) The coin type, defaults to 60 (ETH)
	 * @returns - The Ethereum address of the given name
	 * ```ts
	 * const address = await web3.eth.ens.getAddress('ethereum.eth');
	 * console.log(address);
	 * > '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359'
	 * ```
	 */
	public async getAddress(ENSName: string, coinType = 60) {
		return this._resolver.getAddress(ENSName, coinType);
	}

