### PR TITLE
fix: change getAddress to getOwner

### DIFF
--- a/components/01-atoms/SearchBar.tsx
+++ b/components/01-atoms/SearchBar.tsx
@@ -75,7 +75,7 @@ export const SearchBar = () => {
       const formattedAddress = normalizeENSName(inputAddress);
 
       try {
-        const address: unknown = await ens.getAddress(formattedAddress);
+        const address: unknown = await ens.getOwner(formattedAddress);
         if (typeof address !== "string") {
           toast.error(
             "Wrong type of address returned by provider. Please contact the team",


### PR DESCRIPTION
#320 error, the search-bar not getting the address without the ens name. 
We need to find another solution. Open the issue again.