### PR TITLE
feat: add native ether previews

### DIFF
--- a/components/02-molecules/CardOffers.tsx
+++ b/components/02-molecules/CardOffers.tsx
@@ -104,6 +104,7 @@ export const CardOffers = ({
 
   const VerticalVariantSwapNativeEther = (address: EthereumAddress | null) => {
     if (!address) return null;
+    if (!swapOfferToAccept) return null;
 
     return (
       <div className="flex flex-col justify-content gap-4 md:w-[400px] overflow-x-hidden no-scrollbar">
@@ -111,6 +112,7 @@ export const CardOffers = ({
           address={address}
           variant={UserOfferVariant.SWAP_CREATED}
           nativeEther={nativeEther}
+          swap={swapOfferToAccept}
         />
         <TokensList
           ownerAddress={address}

--- a/components/02-molecules/CardOffers.tsx
+++ b/components/02-molecules/CardOffers.tsx
@@ -11,12 +11,14 @@ import { TokenCardProperties } from "@/components/01-atoms";
 import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import { EthereumAddress, Token } from "@/lib/shared/types";
 import { SwapContext, OffersContext } from "@/lib/client/contexts";
+import { SwapNativeEther } from "@/lib/client/swap-utils";
 import { useContext } from "react";
 
 interface CardOffersProps {
   address: EthereumAddress | null;
   variant?: CreateTokenOfferVariant;
   swapModalAction: SwapModalAction;
+  nativeEther?: SwapNativeEther;
 }
 
 interface CardOfferSConfig {
@@ -27,6 +29,7 @@ export const CardOffers = ({
   address,
   swapModalAction,
   variant = CreateTokenOfferVariant.HORIZONTAL,
+  nativeEther,
 }: CardOffersProps) => {
   const { authenticatedUserAddress } = useAuthenticatedUser();
   const { authenticatedUserTokensList, searchedUserTokensList } =
@@ -78,7 +81,37 @@ export const CardOffers = ({
 
     return (
       <div className="flex flex-col justify-content gap-4 md:w-[400px] overflow-x-hidden no-scrollbar">
-        <UserOfferInfo address={address} variant={UserOfferVariant.SECONDARY} />
+        <UserOfferInfo
+          address={address}
+          variant={UserOfferVariant.CREATING_SWAP}
+        />
+        <TokensList
+          ownerAddress={address}
+          withAddTokenCard={false}
+          withPlaceholders={true}
+          variant={tokenShelfVariant}
+          displayERC20TokensAmount={true}
+          withSelectionValidation={false}
+          tokenCardClickAction={TokenCardActionType.NO_ACTION}
+          tokensList={tokensOfferFor[tokenShelfVariant]}
+          confirmationModalTotalSquares={5}
+          tokenCardStyleType={TokenCardStyleType.MEDIUM}
+          gridClassNames="grid md:grid-cols-5 md:gap-3"
+        />
+      </div>
+    );
+  };
+
+  const VerticalVariantSwapNativeEther = (address: EthereumAddress | null) => {
+    if (!address) return null;
+
+    return (
+      <div className="flex flex-col justify-content gap-4 md:w-[400px] overflow-x-hidden no-scrollbar">
+        <UserOfferInfo
+          address={address}
+          variant={UserOfferVariant.SWAP_CREATED}
+          nativeEther={nativeEther}
+        />
         <TokensList
           ownerAddress={address}
           withAddTokenCard={false}
@@ -105,6 +138,9 @@ export const CardOffers = ({
     },
     [CreateTokenOfferVariant.VERTICAL]: {
       body: VerticalVariant(address),
+    },
+    [CreateTokenOfferVariant.VerticalVariantSwapNativeEther]: {
+      body: VerticalVariantSwapNativeEther(address),
     },
   };
 

--- a/components/02-molecules/CardOffersMarketplace.tsx
+++ b/components/02-molecules/CardOffersMarketplace.tsx
@@ -81,7 +81,7 @@ export const CardOffersMarketplace = ({
     if (!address) return null;
 
     return (
-      <div className="flex flex-col justify-content gap-4 md:w-[400px] overflow-x-hidden no-scrollbar bg-blue-500">
+      <div className="flex flex-col justify-content gap-4 md:w-[400px] overflow-x-hidden no-scrollbar">
         <UserOfferInfo
           address={address}
           variant={UserOfferVariant.CREATING_SWAP}
@@ -107,7 +107,7 @@ export const CardOffersMarketplace = ({
     if (!address) return null;
 
     return (
-      <div className="flex flex-col justify-content gap-4 md:w-[400px] overflow-x-hidden no-scrollbar bg-blue-500">
+      <div className="flex flex-col justify-content gap-4 md:w-[400px] overflow-x-hidden no-scrollbar">
         <UserOfferInfo
           address={address}
           variant={UserOfferVariant.SWAP_CREATED_MARKETPLACE}

--- a/components/02-molecules/CardOffersMarketplace.tsx
+++ b/components/02-molecules/CardOffersMarketplace.tsx
@@ -12,12 +12,14 @@ import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import { EthereumAddress, Token } from "@/lib/shared/types";
 import { SwapContext } from "@/lib/client/contexts";
 import { OffersContextMarketplace } from "@/lib/client/contexts/OffersContextMarketplace";
+import { SwapNativeEther } from "@/lib/client/swap-utils";
 import { useContext } from "react";
 
 interface CardOffersProps {
   address: EthereumAddress | null;
   variant?: CreateTokenOfferVariant;
   swapModalAction: SwapModalAction;
+  nativeEther?: SwapNativeEther;
 }
 
 interface CardOfferSConfig {
@@ -28,6 +30,7 @@ export const CardOffersMarketplace = ({
   address,
   swapModalAction,
   variant = CreateTokenOfferVariant.HORIZONTAL,
+  nativeEther,
 }: CardOffersProps) => {
   const { authenticatedUserAddress } = useAuthenticatedUser();
   const { authenticatedUserTokensList, searchedUserTokensList } =
@@ -78,8 +81,38 @@ export const CardOffersMarketplace = ({
     if (!address) return null;
 
     return (
-      <div className="flex flex-col justify-content gap-4 md:w-[400px] overflow-x-hidden no-scrollbar">
-        <UserOfferInfo address={address} variant={UserOfferVariant.SECONDARY} />
+      <div className="flex flex-col justify-content gap-4 md:w-[400px] overflow-x-hidden no-scrollbar bg-blue-500">
+        <UserOfferInfo
+          address={address}
+          variant={UserOfferVariant.CREATING_SWAP}
+        />
+        <TokensList
+          ownerAddress={address}
+          withAddTokenCard={false}
+          withPlaceholders={true}
+          variant={tokenShelfVariant}
+          displayERC20TokensAmount={true}
+          withSelectionValidation={false}
+          tokenCardClickAction={TokenCardActionType.NO_ACTION}
+          tokensList={tokensOfferFor[tokenShelfVariant]}
+          confirmationModalTotalSquares={5}
+          tokenCardStyleType={TokenCardStyleType.MEDIUM}
+          gridClassNames="grid md:grid-cols-5 md:gap-3"
+        />
+      </div>
+    );
+  };
+
+  const VerticalVariantSwapNativeEther = (address: EthereumAddress | null) => {
+    if (!address) return null;
+
+    return (
+      <div className="flex flex-col justify-content gap-4 md:w-[400px] overflow-x-hidden no-scrollbar bg-blue-500">
+        <UserOfferInfo
+          address={address}
+          variant={UserOfferVariant.SWAP_CREATED}
+          nativeEther={nativeEther}
+        />
         <TokensList
           ownerAddress={address}
           withAddTokenCard={false}
@@ -106,6 +139,9 @@ export const CardOffersMarketplace = ({
     },
     [CreateTokenOfferVariant.VERTICAL]: {
       body: VerticalVariant(address),
+    },
+    [CreateTokenOfferVariant.VerticalVariantSwapNativeEther]: {
+      body: VerticalVariantSwapNativeEther(address),
     },
   };
 

--- a/components/02-molecules/CardOffersMarketplace.tsx
+++ b/components/02-molecules/CardOffersMarketplace.tsx
@@ -110,7 +110,7 @@ export const CardOffersMarketplace = ({
       <div className="flex flex-col justify-content gap-4 md:w-[400px] overflow-x-hidden no-scrollbar bg-blue-500">
         <UserOfferInfo
           address={address}
-          variant={UserOfferVariant.SWAP_CREATED}
+          variant={UserOfferVariant.SWAP_CREATED_MARKETPLACE}
           nativeEther={nativeEther}
         />
         <TokensList

--- a/components/02-molecules/ConfirmSwapModal.tsx
+++ b/components/02-molecules/ConfirmSwapModal.tsx
@@ -16,7 +16,10 @@ import {
   encodeConfig,
   toastBlockchainTxError,
 } from "@/lib/client/blockchain-utils";
-import { CreateTokenOffer } from "@/components/03-organisms";
+import {
+  CreateTokenOffer,
+  CreateTokenOfferVariant,
+} from "@/components/03-organisms";
 import { fromTokensToAssets, getSwapConfig } from "@/lib/client/swap-utils";
 import { SwapModalSteps } from "@/lib/client/ui-utils";
 import { EthereumAddress, Token } from "@/lib/shared/types";
@@ -302,7 +305,14 @@ export const ConfirmSwapModal = ({
             ) : (
               <OfferExpiryConfirmSwap />
             )}
-            <CreateTokenOffer swapModalAction={swapModalAction} />
+            {swapModalAction === SwapModalAction.CREATE_SWAP ? (
+              <CreateTokenOffer swapModalAction={swapModalAction} />
+            ) : (
+              <CreateTokenOffer
+                swapModalAction={swapModalAction}
+                variant={CreateTokenOfferVariant.VerticalVariantSwapNativeEther}
+              />
+            )}
           </div>
         }
         footer={
@@ -342,7 +352,14 @@ export const ConfirmSwapModal = ({
             ) : (
               <OfferExpiryConfirmSwap />
             )}
-            <CreateTokenOffer swapModalAction={swapModalAction} />
+            {swapModalAction === SwapModalAction.CREATE_SWAP ? (
+              <CreateTokenOffer swapModalAction={swapModalAction} />
+            ) : (
+              <CreateTokenOffer
+                swapModalAction={swapModalAction}
+                variant={CreateTokenOfferVariant.VerticalVariantSwapNativeEther}
+              />
+            )}
           </div>
         }
         footer={
@@ -367,8 +384,15 @@ export const ConfirmSwapModal = ({
               <OfferExpiryConfirmSwapStation />
             ) : (
               <OfferExpiryConfirmSwap />
-            )}{" "}
-            <CreateTokenOffer swapModalAction={swapModalAction} />
+            )}
+            {swapModalAction === SwapModalAction.CREATE_SWAP ? (
+              <CreateTokenOffer swapModalAction={swapModalAction} />
+            ) : (
+              <CreateTokenOffer
+                swapModalAction={swapModalAction}
+                variant={CreateTokenOfferVariant.VerticalVariantSwapNativeEther}
+              />
+            )}
           </div>
         }
         footer={

--- a/components/02-molecules/ConfirmSwapModal.tsx
+++ b/components/02-molecules/ConfirmSwapModal.tsx
@@ -238,6 +238,7 @@ export const ConfirmSwapModal = ({
               chainId,
             );
 
+            console.log("etherRecipient", etherRecipient);
             // Create swap
             const msgValueCreateSwap =
               etherRecipient == 0 ? etherValue : BigInt(0);

--- a/components/02-molecules/ConfirmSwapModalMarketplace.tsx
+++ b/components/02-molecules/ConfirmSwapModalMarketplace.tsx
@@ -1,7 +1,10 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { ProgressStatusMarketplace } from "./ProgressStatusMarketplace";
 import { ApproveTokenCardsMarketplace } from "../01-atoms/ApproveTokenCardsMarketplace";
-import { CreateTokenOfferMarketplace } from "../03-organisms/CreateTokenOfferMarketplace";
+import {
+  CreateTokenOfferMarketplace,
+  CreateTokenOfferVariant,
+} from "../03-organisms/CreateTokenOfferMarketplace";
 import { OfferExpiryConfirmSwapMarketplace } from "../01-atoms/OfferExpiryConfirmSwapMarketplace";
 import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import {
@@ -247,7 +250,14 @@ export const ConfirmSwapModalMarketplace = ({
         body={
           <div className="flex flex-col gap-2 flex-grow">
             <OfferExpiryConfirmSwapMarketplace />
-            <CreateTokenOfferMarketplace swapModalAction={swapModalAction} />
+            {swapModalAction === SwapModalAction.CREATE_SWAP ? (
+              <CreateTokenOfferMarketplace swapModalAction={swapModalAction} />
+            ) : (
+              <CreateTokenOfferMarketplace
+                swapModalAction={swapModalAction}
+                variant={CreateTokenOfferVariant.VerticalVariantSwapNativeEther}
+              />
+            )}
           </div>
         }
         footer={
@@ -283,7 +293,14 @@ export const ConfirmSwapModalMarketplace = ({
         body={
           <div className="flex flex-col gap-2 flex-grow">
             <OfferExpiryConfirmSwapMarketplace />
-            <CreateTokenOfferMarketplace swapModalAction={swapModalAction} />
+            {swapModalAction === SwapModalAction.CREATE_SWAP ? (
+              <CreateTokenOfferMarketplace swapModalAction={swapModalAction} />
+            ) : (
+              <CreateTokenOfferMarketplace
+                swapModalAction={swapModalAction}
+                variant={CreateTokenOfferVariant.VerticalVariantSwapNativeEther}
+              />
+            )}
           </div>
         }
         footer={
@@ -305,7 +322,14 @@ export const ConfirmSwapModalMarketplace = ({
         body={
           <div className="flex flex-col gap-2 flex-grow">
             <OfferExpiryConfirmSwapMarketplace />
-            <CreateTokenOfferMarketplace swapModalAction={swapModalAction} />
+            {swapModalAction === SwapModalAction.CREATE_SWAP ? (
+              <CreateTokenOfferMarketplace swapModalAction={swapModalAction} />
+            ) : (
+              <CreateTokenOfferMarketplace
+                swapModalAction={swapModalAction}
+                variant={CreateTokenOfferVariant.VerticalVariantSwapNativeEther}
+              />
+            )}
           </div>
         }
         footer={

--- a/components/02-molecules/OfferSummary.tsx
+++ b/components/02-molecules/OfferSummary.tsx
@@ -65,7 +65,7 @@ export const OfferSummary = ({ variant }: { variant: ForWhom }) => {
                         : validatedAddressToSwap
                         ? `${
                             validatedAddressToSwap.address === ADDRESS_ZERO
-                              ? "Any user"
+                              ? "Any user offers"
                               : validatedAddressToSwap.getEllipsedAddress() +
                                 " offers"
                           } `

--- a/components/02-molecules/OfferSummary.tsx
+++ b/components/02-molecules/OfferSummary.tsx
@@ -85,7 +85,7 @@ export const OfferSummary = ({ variant }: { variant: ForWhom }) => {
               </p>
             </div>
           </div>
-          {variant === ForWhom.Yours && (
+          {variant === ForWhom.Yours && authenticatedUserAddress && (
             <EtherFieldAddition variant={ForWhom.Yours} />
           )}
           {variant === ForWhom.Their && validatedAddressToSwap && (

--- a/components/02-molecules/SwapOfferCard.tsx
+++ b/components/02-molecules/SwapOfferCard.tsx
@@ -10,8 +10,10 @@ import { TokenCardProperties } from "@/components/01-atoms";
 import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import { EthereumAddress, Token } from "@/lib/shared/types";
 import { SwapNativeEther } from "@/lib/client/swap-utils";
+import { PopulatedSwapOfferCard } from "@/lib/client/offers-utils";
 
 interface SwapOfferCardProps {
+  swap?: PopulatedSwapOfferCard;
   address: EthereumAddress | null;
   tokens?: Token[];
   nativeEther?: SwapNativeEther;
@@ -23,6 +25,7 @@ interface SwapOfferCardProps {
  */
 
 export const SwapOfferCard = ({
+  swap,
   address,
   tokens,
   nativeEther,
@@ -40,6 +43,7 @@ export const SwapOfferCard = ({
           address={address}
           variant={UserOfferVariant.SWAP_CREATED}
           nativeEther={nativeEther}
+          swap={swap}
         />
         <div className="mb-auto max-h-[100px] overflow-auto no-scrollbar">
           <TokensSwapList

--- a/components/02-molecules/SwapOfferCard.tsx
+++ b/components/02-molecules/SwapOfferCard.tsx
@@ -9,13 +9,24 @@ import {
 import { TokenCardProperties } from "@/components/01-atoms";
 import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import { EthereumAddress, Token } from "@/lib/shared/types";
+import { SwapNativeEther } from "@/lib/client/swap-utils";
 
 interface SwapOfferCardProps {
   address: EthereumAddress | null;
   tokens?: Token[];
+  nativeEther?: SwapNativeEther;
 }
 
-export const SwapOfferCard = ({ address, tokens }: SwapOfferCardProps) => {
+/**
+ * Renders a swap offer card component.
+ * OffersPage.tsx uses the SwapOffers and this component to render the swap offer cards.
+ */
+
+export const SwapOfferCard = ({
+  address,
+  tokens,
+  nativeEther,
+}: SwapOfferCardProps) => {
   const { authenticatedUserAddress } = useAuthenticatedUser();
 
   const tokenShelfVariant = authenticatedUserAddress?.equals(address)
@@ -25,7 +36,11 @@ export const SwapOfferCard = ({ address, tokens }: SwapOfferCardProps) => {
   return (
     <div className="md:p-4">
       <div className="flex flex-col justify-between h-full gap-4 md:w-[326px]">
-        <UserOfferInfo address={address} variant={UserOfferVariant.SECONDARY} />
+        <UserOfferInfo
+          address={address}
+          variant={UserOfferVariant.SWAP_CREATED}
+          nativeEther={nativeEther}
+        />
         <div className="mb-auto max-h-[100px] overflow-auto no-scrollbar">
           <TokensSwapList
             ownerAddress={authenticatedUserAddress}

--- a/components/02-molecules/SwapOfferCardMarketplace.tsx
+++ b/components/02-molecules/SwapOfferCardMarketplace.tsx
@@ -9,15 +9,18 @@ import {
 import { TokenCardProperties } from "@/components/01-atoms";
 import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import { EthereumAddress, Token } from "@/lib/shared/types";
+import { SwapNativeEther } from "@/lib/client/swap-utils";
 
 interface SwapOfferCardProps {
   address: EthereumAddress | null;
   tokens?: Token[];
+  nativeEther?: SwapNativeEther;
 }
 
 export const SwapOfferCardMarketplace = ({
   address,
   tokens,
+  nativeEther,
 }: SwapOfferCardProps) => {
   const { authenticatedUserAddress } = useAuthenticatedUser();
 
@@ -25,10 +28,15 @@ export const SwapOfferCardMarketplace = ({
     ? ForWhom.Yours
     : ForWhom.Their;
 
+  console.log("nativeEther,,,", nativeEther);
   return (
     <div className="md:p-4">
       <div className="flex flex-col justify-between h-full gap-4 md:w-[326px]">
-        <UserOfferInfo address={address} variant={UserOfferVariant.SECONDARY} />
+        <UserOfferInfo
+          address={address}
+          variant={UserOfferVariant.SWAP_CREATED}
+          nativeEther={nativeEther}
+        />
         <div className="mb-auto max-h-[100px] overflow-auto no-scrollbar">
           <TokensSwapList
             ownerAddress={authenticatedUserAddress}

--- a/components/02-molecules/SwapOfferCardMarketplace.tsx
+++ b/components/02-molecules/SwapOfferCardMarketplace.tsx
@@ -28,13 +28,12 @@ export const SwapOfferCardMarketplace = ({
     ? ForWhom.Yours
     : ForWhom.Their;
 
-  console.log("nativeEther,,,", nativeEther);
   return (
     <div className="md:p-4">
       <div className="flex flex-col justify-between h-full gap-4 md:w-[326px]">
         <UserOfferInfo
           address={address}
-          variant={UserOfferVariant.SWAP_CREATED}
+          variant={UserOfferVariant.SWAP_CREATED_MARKETPLACE}
           nativeEther={nativeEther}
         />
         <div className="mb-auto max-h-[100px] overflow-auto no-scrollbar">

--- a/components/02-molecules/UserOfferInfo.tsx
+++ b/components/02-molecules/UserOfferInfo.tsx
@@ -3,6 +3,7 @@ import { ADDRESS_ZERO } from "@/lib/client/constants";
 import { SwapContext } from "@/lib/client/contexts";
 import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import { useEnsData } from "@/lib/client/hooks/useENSData";
+import { SwapNativeEther } from "@/lib/client/swap-utils";
 import { isInRange } from "@/lib/client/utils";
 import { EthereumAddress } from "@/lib/shared/types";
 import { useContext, useEffect, useState } from "react";
@@ -10,17 +11,26 @@ import { formatEther } from "viem";
 import { useNetwork } from "wagmi";
 
 export enum UserOfferVariant {
-  DEFAULT = "default",
-  SECONDARY = "secondary",
+  NAME_ENS = "NAME_ENS", // only the name of the ENS and avatar
+  CREATING_SWAP = "CREATING_SWAP", // the name of the ENS and avatar with the amount of ether being sent ( etherValue )
+  SWAP_CREATED = "SWAP_CREATED", // the name of the ENS and avatar with the amount of ether in the swap already created
 }
 interface UserOfferInfoProps {
   address: EthereumAddress | null;
   variant?: UserOfferVariant;
+  nativeEther?: SwapNativeEther;
 }
 
+/**
+ * Renders the user offer information based on the provided props.
+ * The component will render the ENS name and avatar of the user.
+ * The component variant will render the amount of ether being sent in the swap or the amount of ether in the swap already created.
+ *
+ */
 export const UserOfferInfo = ({
   address,
-  variant = UserOfferVariant.DEFAULT,
+  variant = UserOfferVariant.NAME_ENS,
+  nativeEther,
 }: UserOfferInfoProps) => {
   const { primaryName } = useEnsData({
     ensAddress: address,
@@ -39,22 +49,19 @@ export const UserOfferInfo = ({
     /* Only render the chain symbol after the component has mounted */
     setIsMounted(true);
   }, []);
-  return variant == UserOfferVariant.DEFAULT ? (
-    <div>
-      <div className="flex gap-2">
-        <div>
-          {address && (
-            <ENSAvatar avatarENSAddress={address} size={ENSAvatarSize.SMALL} />
-          )}
-        </div>
-        <div className="flex ">
-          {primaryName ? <p>{primaryName}</p> : <p>{displayAddress}</p>}
-        </div>
-      </div>
-    </div>
-  ) : variant === UserOfferVariant.SECONDARY ? (
-    <div>
-      <div className="flex justify-between">
+
+  let displayNativeEther = 0;
+
+  if (nativeEther) {
+    displayNativeEther = Number(nativeEther.value) / 1e6;
+  }
+
+  console.log("nativeEther", nativeEther);
+  console.log("displayNativeEther", displayNativeEther);
+
+  const UserOfferInfoConfig: Record<UserOfferVariant, JSX.Element> = {
+    [UserOfferVariant.NAME_ENS]: (
+      <div>
         <div className="flex gap-2">
           <div>
             {address && (
@@ -65,39 +72,107 @@ export const UserOfferInfo = ({
             )}
           </div>
           <div className="flex ">
-            {primaryName ? (
-              <p>{primaryName} gets</p>
-            ) : (
-              <p>{displayAddress} gets</p>
-            )}
+            {primaryName ? <p>{primaryName}</p> : <p>{displayAddress}</p>}
           </div>
         </div>
-        {address?.address !== authenticatedUserAddress?.address &&
-        etherRecipient === 0 ? (
-          <div className="flex-row flex items-center gap-1">
-            <p className="flex dark:p-small-dark p-small-variant-black">
-              {formatEther(etherValue).toString()}
-            </p>
-            <p className="flex dark:p-small-dark p-small-variant-black">
-              {isMounted && chain ? chain.nativeCurrency.symbol : ""}
-            </p>
-          </div>
-        ) : address?.address === authenticatedUserAddress?.address &&
-          isInRange(etherRecipient, 1, 255) ? (
-          <div className="flex-row flex items-center gap-1">
-            <p className="flex dark:p-small-dark p-small-variant-black">
-              {formatEther(etherValue).toString()}
-            </p>
-            <p className="flex dark:p-small-dark p-small-variant-black">
-              {isMounted && chain ? chain.nativeCurrency.symbol : ""}
-            </p>
-          </div>
-        ) : (
-          <></>
-        )}
       </div>
-    </div>
-  ) : (
-    <></>
-  );
+    ),
+    [UserOfferVariant.CREATING_SWAP]: (
+      <div>
+        <div className="flex justify-between">
+          <div className="flex gap-2">
+            <div>
+              {address && (
+                <ENSAvatar
+                  avatarENSAddress={address}
+                  size={ENSAvatarSize.SMALL}
+                />
+              )}
+            </div>
+            <div className="flex ">
+              {primaryName ? (
+                <p>{primaryName} gets</p>
+              ) : (
+                <p>{displayAddress} gets</p>
+              )}
+            </div>
+          </div>
+          {address?.address !== authenticatedUserAddress?.address &&
+          etherRecipient === 0 ? (
+            <div className="flex-row flex items-center gap-1">
+              <p className="flex dark:p-small-dark p-small-variant-black">
+                {formatEther(etherValue).toString()}
+              </p>
+              <p className="flex dark:p-small-dark p-small-variant-black">
+                {isMounted && chain ? chain.nativeCurrency.symbol : ""}
+              </p>
+            </div>
+          ) : address?.address === authenticatedUserAddress?.address &&
+            isInRange(etherRecipient, 1, 255) ? (
+            <div className="flex-row flex items-center gap-1">
+              <p className="flex dark:p-small-dark p-small-variant-black">
+                {formatEther(etherValue).toString()}
+              </p>
+              <p className="flex dark:p-small-dark p-small-variant-black">
+                {isMounted && chain ? chain.nativeCurrency.symbol : ""}
+              </p>
+            </div>
+          ) : (
+            <></>
+          )}
+        </div>
+      </div>
+    ),
+    [UserOfferVariant.SWAP_CREATED]: (
+      <div>
+        <div className="flex justify-between">
+          <div className="flex gap-2">
+            <div>
+              {address && (
+                <ENSAvatar
+                  avatarENSAddress={address}
+                  size={ENSAvatarSize.SMALL}
+                />
+              )}
+            </div>
+            <div className="flex ">
+              {primaryName ? (
+                <p>{primaryName} gets</p>
+              ) : (
+                <p>{displayAddress} gets</p>
+              )}
+            </div>
+          </div>
+          {address?.address !== authenticatedUserAddress?.address &&
+          nativeEther &&
+          nativeEther.recipient === BigInt(0) ? (
+            <div className="flex-row flex items-center gap-1">
+              <p className="flex dark:p-small-dark p-small-variant-black">
+                {displayNativeEther.toString()}
+              </p>
+              <p className="flex dark:p-small-dark p-small-variant-black">
+                {isMounted && chain ? chain.nativeCurrency.symbol : ""}
+              </p>
+            </div>
+          ) : address?.address === authenticatedUserAddress?.address &&
+            nativeEther &&
+            nativeEther.recipient !== BigInt(0) &&
+            isInRange(Number(nativeEther.recipient), 1, 255) ? (
+            <div className="flex-row flex items-center gap-1">
+              <p className="flex dark:p-small-dark p-small-variant-black">
+                {displayNativeEther.toString()}
+              </p>
+              <p className="flex dark:p-small-dark p-small-variant-black">
+                {isMounted && chain ? chain.nativeCurrency.symbol : ""}
+              </p>
+            </div>
+          ) : (
+            <></>
+          )}
+        </div>
+      </div>
+    ),
+  };
+
+  return UserOfferInfoConfig[variant];
 };

--- a/components/02-molecules/UserOfferInfo.tsx
+++ b/components/02-molecules/UserOfferInfo.tsx
@@ -3,6 +3,7 @@ import { ADDRESS_ZERO } from "@/lib/client/constants";
 import { SwapContext } from "@/lib/client/contexts";
 import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import { useEnsData } from "@/lib/client/hooks/useENSData";
+import { PopulatedSwapOfferCard } from "@/lib/client/offers-utils";
 import { SwapNativeEther } from "@/lib/client/swap-utils";
 import { isInRange } from "@/lib/client/utils";
 import { EthereumAddress } from "@/lib/shared/types";
@@ -20,6 +21,7 @@ interface UserOfferInfoProps {
   address: EthereumAddress | null;
   variant?: UserOfferVariant;
   nativeEther?: SwapNativeEther;
+  swap?: PopulatedSwapOfferCard;
 }
 
 /**
@@ -32,6 +34,7 @@ export const UserOfferInfo = ({
   address,
   variant = UserOfferVariant.NAME_ENS,
   nativeEther,
+  swap,
 }: UserOfferInfoProps) => {
   const { primaryName } = useEnsData({
     ensAddress: address,
@@ -40,7 +43,6 @@ export const UserOfferInfo = ({
   const [isMounted, setIsMounted] = useState(false);
   const { chain } = useNetwork();
   const { authenticatedUserAddress } = useAuthenticatedUser();
-
   const displayAddress =
     address?.address === ADDRESS_ZERO
       ? "Acceptor"
@@ -56,6 +58,8 @@ export const UserOfferInfo = ({
   if (nativeEther) {
     displayNativeEther = Number(nativeEther.value) / 1e6;
   }
+
+  console.log("nativeEther.recipient", nativeEther?.recipient);
 
   const UserOfferInfoConfig: Record<UserOfferVariant, JSX.Element> = {
     [UserOfferVariant.NAME_ENS]: (
@@ -141,9 +145,9 @@ export const UserOfferInfo = ({
               )}
             </div>
           </div>
-          {address?.address === authenticatedUserAddress?.address &&
-          nativeEther &&
-          nativeEther.recipient !== BigInt(0) ? (
+          {nativeEther &&
+          nativeEther.recipient === BigInt(0) &&
+          address === swap?.askerTokens.address ? (
             <div className="flex-row flex items-center gap-1">
               <p className="flex dark:p-small-dark p-small-variant-black">
                 {displayNativeEther.toString()}
@@ -152,9 +156,9 @@ export const UserOfferInfo = ({
                 {isMounted && chain ? chain.nativeCurrency.symbol : ""}
               </p>
             </div>
-          ) : address?.address !== authenticatedUserAddress?.address &&
-            nativeEther &&
-            nativeEther.recipient === BigInt(0) ? (
+          ) : nativeEther &&
+            nativeEther.recipient !== BigInt(0) &&
+            address !== swap?.askerTokens.address ? (
             <div className="flex-row flex items-center gap-1">
               <p className="flex dark:p-small-dark p-small-variant-black">
                 {displayNativeEther.toString()}

--- a/components/02-molecules/UserOfferInfo.tsx
+++ b/components/02-molecules/UserOfferInfo.tsx
@@ -56,8 +56,10 @@ export const UserOfferInfo = ({
     displayNativeEther = Number(nativeEther.value) / 1e6;
   }
 
-  console.log("nativeEther", nativeEther);
-  console.log("displayNativeEther", displayNativeEther);
+  // console.log("nativeEther", nativeEther);
+  // console.log("displayNativeEther", displayNativeEther);
+  // console.log("address", address);
+  // console.log("authenticatedUserAddress", authenticatedUserAddress);
 
   const UserOfferInfoConfig: Record<UserOfferVariant, JSX.Element> = {
     [UserOfferVariant.NAME_ENS]: (
@@ -145,7 +147,7 @@ export const UserOfferInfo = ({
           </div>
           {address?.address !== authenticatedUserAddress?.address &&
           nativeEther &&
-          nativeEther.recipient === BigInt(0) ? (
+          nativeEther.recipient !== BigInt(0) ? (
             <div className="flex-row flex items-center gap-1">
               <p className="flex dark:p-small-dark p-small-variant-black">
                 {displayNativeEther.toString()}
@@ -156,7 +158,7 @@ export const UserOfferInfo = ({
             </div>
           ) : address?.address === authenticatedUserAddress?.address &&
             nativeEther &&
-            nativeEther.recipient !== BigInt(0) &&
+            nativeEther.recipient === BigInt(0) &&
             isInRange(Number(nativeEther.recipient), 1, 255) ? (
             <div className="flex-row flex items-center gap-1">
               <p className="flex dark:p-small-dark p-small-variant-black">

--- a/components/02-molecules/UserOfferInfo.tsx
+++ b/components/02-molecules/UserOfferInfo.tsx
@@ -56,11 +56,6 @@ export const UserOfferInfo = ({
     displayNativeEther = Number(nativeEther.value) / 1e6;
   }
 
-  // console.log("nativeEther", nativeEther);
-  // console.log("displayNativeEther", displayNativeEther);
-  // console.log("address", address);
-  // console.log("authenticatedUserAddress", authenticatedUserAddress);
-
   const UserOfferInfoConfig: Record<UserOfferVariant, JSX.Element> = {
     [UserOfferVariant.NAME_ENS]: (
       <div>
@@ -169,6 +164,34 @@ export const UserOfferInfo = ({
               </p>
             </div>
           ) : (
+            // ) : address?.address === ADDRESS_ZERO &&
+            //   nativeEther &&
+            //   nativeEther.recipient === BigInt(0) &&
+            //   nativeEther.value !== BigInt(0) ? (
+            //   <>
+            //     <div className="flex-row flex items-center gap-1 dark:!bg-blue-500">
+            //       <p className="flex dark:p-small-dark p-small-variant-black">
+            //         {displayNativeEther.toString()}
+            //       </p>
+            //       <p className="flex dark:p-small-dark p-small-variant-black">
+            //         {isMounted && chain ? chain.nativeCurrency.symbol : ""}
+            //       </p>
+            //     </div>
+            //   </>
+            // ) : address?.address !== ADDRESS_ZERO &&
+            //   address?.address !== authenticatedUserAddress?.address &&
+            //   nativeEther &&
+            //   nativeEther.recipient !== BigInt(0) ? (
+            //   <>
+            //     <div className="flex-row flex items-center gap-1 dark:!bg-red-500">
+            //       <p className="flex dark:p-small-dark p-small-variant-black">
+            //         {displayNativeEther.toString()}
+            //       </p>
+            //       <p className="flex dark:p-small-dark p-small-variant-black">
+            //         {isMounted && chain ? chain.nativeCurrency.symbol : ""}
+            //       </p>
+            //     </div>
+            //   </>
             <></>
           )}
         </div>

--- a/components/02-molecules/UserOfferInfo.tsx
+++ b/components/02-molecules/UserOfferInfo.tsx
@@ -143,7 +143,7 @@ export const UserOfferInfo = ({
           </div>
           {address?.address !== authenticatedUserAddress?.address &&
           nativeEther &&
-          nativeEther.recipient !== BigInt(0) ? ( // Inverted to display correct in the UI
+          nativeEther.recipient !== BigInt(0) ? (
             <div className="flex-row flex items-center gap-1">
               <p className="flex dark:p-small-dark p-small-variant-black">
                 {displayNativeEther.toString()}
@@ -154,8 +154,7 @@ export const UserOfferInfo = ({
             </div>
           ) : address?.address === authenticatedUserAddress?.address &&
             nativeEther &&
-            nativeEther.recipient === BigInt(0) && // Inverted to display correct in the UI
-            isInRange(Number(nativeEther.recipient), 1, 255) ? (
+            nativeEther.recipient === BigInt(0) ? (
             <div className="flex-row flex items-center gap-1">
               <p className="flex dark:p-small-dark p-small-variant-black">
                 {displayNativeEther.toString()}

--- a/components/02-molecules/UserOfferInfo.tsx
+++ b/components/02-molecules/UserOfferInfo.tsx
@@ -59,8 +59,6 @@ export const UserOfferInfo = ({
     displayNativeEther = Number(nativeEther.value) / 1e6;
   }
 
-  console.log("nativeEther.recipient", nativeEther?.recipient);
-
   const UserOfferInfoConfig: Record<UserOfferVariant, JSX.Element> = {
     [UserOfferVariant.NAME_ENS]: (
       <div>

--- a/components/02-molecules/UserOfferInfo.tsx
+++ b/components/02-molecules/UserOfferInfo.tsx
@@ -14,6 +14,7 @@ export enum UserOfferVariant {
   NAME_ENS = "NAME_ENS", // only the name of the ENS and avatar
   CREATING_SWAP = "CREATING_SWAP", // the name of the ENS and avatar with the amount of ether being sent ( etherValue )
   SWAP_CREATED = "SWAP_CREATED", // the name of the ENS and avatar with the amount of ether in the swap already created
+  SWAP_CREATED_MARKETPLACE = "SWAP_CREATED_MARKETPLACE", // the name of the ENS and avatar with the amount of ether in the swap already created
 }
 interface UserOfferInfoProps {
   address: EthereumAddress | null;
@@ -164,34 +165,58 @@ export const UserOfferInfo = ({
               </p>
             </div>
           ) : (
-            // ) : address?.address === ADDRESS_ZERO &&
-            //   nativeEther &&
-            //   nativeEther.recipient === BigInt(0) &&
-            //   nativeEther.value !== BigInt(0) ? (
-            //   <>
-            //     <div className="flex-row flex items-center gap-1 dark:!bg-blue-500">
-            //       <p className="flex dark:p-small-dark p-small-variant-black">
-            //         {displayNativeEther.toString()}
-            //       </p>
-            //       <p className="flex dark:p-small-dark p-small-variant-black">
-            //         {isMounted && chain ? chain.nativeCurrency.symbol : ""}
-            //       </p>
-            //     </div>
-            //   </>
-            // ) : address?.address !== ADDRESS_ZERO &&
-            //   address?.address !== authenticatedUserAddress?.address &&
-            //   nativeEther &&
-            //   nativeEther.recipient !== BigInt(0) ? (
-            //   <>
-            //     <div className="flex-row flex items-center gap-1 dark:!bg-red-500">
-            //       <p className="flex dark:p-small-dark p-small-variant-black">
-            //         {displayNativeEther.toString()}
-            //       </p>
-            //       <p className="flex dark:p-small-dark p-small-variant-black">
-            //         {isMounted && chain ? chain.nativeCurrency.symbol : ""}
-            //       </p>
-            //     </div>
-            //   </>
+            <></>
+          )}
+        </div>
+      </div>
+    ),
+    [UserOfferVariant.SWAP_CREATED_MARKETPLACE]: (
+      <div>
+        <div className="flex justify-between">
+          <div className="flex gap-2">
+            <div>
+              {address && (
+                <ENSAvatar
+                  avatarENSAddress={address}
+                  size={ENSAvatarSize.SMALL}
+                />
+              )}
+            </div>
+            <div className="flex">
+              {primaryName ? (
+                <p>{primaryName} gets</p>
+              ) : (
+                <p>{displayAddress} gets</p>
+              )}
+            </div>
+          </div>
+          {address?.address !== ADDRESS_ZERO &&
+          nativeEther &&
+          nativeEther.recipient !== BigInt(0) ? (
+            <>
+              <div className="flex-row flex items-center gap-1">
+                <p className="flex dark:p-small-dark p-small-variant-black">
+                  {displayNativeEther.toString()}
+                </p>
+                <p className="flex dark:p-small-dark p-small-variant-black">
+                  {isMounted && chain ? chain.nativeCurrency.symbol : ""}
+                </p>
+              </div>
+            </>
+          ) : address?.address === ADDRESS_ZERO &&
+            nativeEther &&
+            nativeEther.recipient === BigInt(0) ? (
+            <>
+              <div className="flex-row flex items-center gap-1">
+                <p className="flex dark:p-small-dark p-small-variant-black">
+                  {displayNativeEther.toString()}
+                </p>
+                <p className="flex dark:p-small-dark p-small-variant-black">
+                  {isMounted && chain ? chain.nativeCurrency.symbol : ""}
+                </p>
+              </div>
+            </>
+          ) : (
             <></>
           )}
         </div>

--- a/components/02-molecules/UserOfferInfo.tsx
+++ b/components/02-molecules/UserOfferInfo.tsx
@@ -147,7 +147,7 @@ export const UserOfferInfo = ({
           </div>
           {address?.address !== authenticatedUserAddress?.address &&
           nativeEther &&
-          nativeEther.recipient !== BigInt(0) ? (
+          nativeEther.recipient !== BigInt(0) ? ( // Inverted to display correct in the UI
             <div className="flex-row flex items-center gap-1">
               <p className="flex dark:p-small-dark p-small-variant-black">
                 {displayNativeEther.toString()}
@@ -158,7 +158,7 @@ export const UserOfferInfo = ({
             </div>
           ) : address?.address === authenticatedUserAddress?.address &&
             nativeEther &&
-            nativeEther.recipient === BigInt(0) &&
+            nativeEther.recipient === BigInt(0) && // Inverted to display correct in the UI
             isInRange(Number(nativeEther.recipient), 1, 255) ? (
             <div className="flex-row flex items-center gap-1">
               <p className="flex dark:p-small-dark p-small-variant-black">

--- a/components/02-molecules/UserOfferInfo.tsx
+++ b/components/02-molecules/UserOfferInfo.tsx
@@ -141,7 +141,7 @@ export const UserOfferInfo = ({
               )}
             </div>
           </div>
-          {address?.address !== authenticatedUserAddress?.address &&
+          {address?.address === authenticatedUserAddress?.address &&
           nativeEther &&
           nativeEther.recipient !== BigInt(0) ? (
             <div className="flex-row flex items-center gap-1">
@@ -152,7 +152,7 @@ export const UserOfferInfo = ({
                 {isMounted && chain ? chain.nativeCurrency.symbol : ""}
               </p>
             </div>
-          ) : address?.address === authenticatedUserAddress?.address &&
+          ) : address?.address !== authenticatedUserAddress?.address &&
             nativeEther &&
             nativeEther.recipient === BigInt(0) ? (
             <div className="flex-row flex items-center gap-1">

--- a/components/03-organisms/CreateTokenOffer.tsx
+++ b/components/03-organisms/CreateTokenOffer.tsx
@@ -53,8 +53,8 @@ export const CreateTokenOffer = ({
 
   if (swapOfferToAccept) {
     nativeEtherSwap = {
-      recipient: swapOfferToAccept.recipient,
-      value: swapOfferToAccept.value,
+      recipient: BigInt(swapOfferToAccept.recipient),
+      value: BigInt(swapOfferToAccept.value),
     };
   }
 

--- a/components/03-organisms/CreateTokenOffer.tsx
+++ b/components/03-organisms/CreateTokenOffer.tsx
@@ -3,12 +3,14 @@ import { SwapIcon, SwapIconVariant } from "@/components/01-atoms";
 import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import { PopulatedSwapOfferCard } from "@/lib/client/offers-utils";
 import { OffersContext, SwapContext } from "@/lib/client/contexts";
+import { SwapNativeEther } from "@/lib/client/swap-utils";
 import cc from "classcat";
 import { useContext } from "react";
 
 export enum CreateTokenOfferVariant {
-  HORIZONTAL = "horizontal",
-  VERTICAL = "vertical",
+  HORIZONTAL,
+  VERTICAL,
+  VerticalVariantSwapNativeEther,
 }
 
 interface CreateTokenOfferProps {
@@ -45,6 +47,15 @@ export const CreateTokenOffer = ({
     !swapOfferToAccept
   ) {
     return null;
+  }
+
+  let nativeEtherSwap: SwapNativeEther;
+
+  if (swapOfferToAccept) {
+    nativeEtherSwap = {
+      recipient: swapOfferToAccept.recipient,
+      value: swapOfferToAccept.value,
+    };
   }
 
   const HorizontalVariant = () => {
@@ -122,6 +133,48 @@ export const CreateTokenOffer = ({
     );
   };
 
+  const VerticalVariantSwapNativeEther = () => {
+    return (
+      <div className="flex flex-col rounded-lg flex-grow">
+        <div className="flex flex-col relative gap-2 flex-grow">
+          <div className="p-4 relative flex flex-grow border border-[#353836] rounded-lg dark:bg-[#282B29]">
+            <CardOffers
+              swapModalAction={swapModalAction}
+              address={
+                swapModalAction === SwapModalAction.CREATE_SWAP
+                  ? authenticatedUserAddress
+                  : (swapOfferToAccept as PopulatedSwapOfferCard).askerTokens
+                      .address
+              }
+              variant={CreateTokenOfferVariant.VerticalVariantSwapNativeEther}
+              nativeEther={nativeEtherSwap}
+            />
+          </div>
+
+          <div className="w-full relative">
+            <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 border dark:border-[#353836] border-[#707572] bg-[#F6F6F6] dark:bg-[#212322] rounded-full w-9 h-9 flex items-center justify-center">
+              <SwapIcon variant={SwapIconVariant.VERTICAL} />
+            </div>
+          </div>
+
+          <div className="p-4 flex flex-grow border border-[#353836] rounded-lg dark:bg-[#282B29]">
+            <CardOffers
+              swapModalAction={swapModalAction}
+              address={
+                swapModalAction === SwapModalAction.CREATE_SWAP
+                  ? validatedAddressToSwap
+                  : (swapOfferToAccept as PopulatedSwapOfferCard).bidderTokens
+                      .address
+              }
+              variant={CreateTokenOfferVariant.VerticalVariantSwapNativeEther}
+              nativeEther={nativeEtherSwap}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   const CreateTokenOfferPropsConfig: Record<
     CreateTokenOfferVariant,
     CreateTokenOfferConfig
@@ -131,6 +184,9 @@ export const CreateTokenOffer = ({
     },
     [CreateTokenOfferVariant.VERTICAL]: {
       body: <VerticalVariant />,
+    },
+    [CreateTokenOfferVariant.VerticalVariantSwapNativeEther]: {
+      body: <VerticalVariantSwapNativeEther />, // This is the same as the VerticalVariant but using the nativeEtherSwap
     },
   };
 

--- a/components/03-organisms/CreateTokenOfferMarketplace.tsx
+++ b/components/03-organisms/CreateTokenOfferMarketplace.tsx
@@ -137,7 +137,7 @@ export const CreateTokenOfferMarketplace = ({
 
   const VerticalVariantSwapNativeEther = () => {
     return (
-      <div className="flex flex-col rounded-lg flex-grow dark:!bg-red-500">
+      <div className="flex flex-col rounded-lg flex-grow">
         <div className="flex flex-col relative gap-2 flex-grow">
           <div className="p-4 relative flex flex-grow border border-[#353836] rounded-lg dark:bg-[#282B29]">
             <CardOffersMarketplace

--- a/components/03-organisms/CreateTokenOfferMarketplace.tsx
+++ b/components/03-organisms/CreateTokenOfferMarketplace.tsx
@@ -5,12 +5,14 @@ import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import { PopulatedSwapOfferCard } from "@/lib/client/offers-utils";
 import { SwapContext } from "@/lib/client/contexts";
 import { OffersContextMarketplace } from "@/lib/client/contexts/OffersContextMarketplace";
+import { SwapNativeEther } from "@/lib/client/swap-utils";
 import cc from "classcat";
 import { useContext } from "react";
 
 export enum CreateTokenOfferVariant {
-  HORIZONTAL = "horizontal",
-  VERTICAL = "vertical",
+  HORIZONTAL,
+  VERTICAL,
+  VerticalVariantSwapNativeEther,
 }
 
 interface CreateTokenOfferProps {
@@ -47,6 +49,15 @@ export const CreateTokenOfferMarketplace = ({
     !swapOfferToAccept
   ) {
     return null;
+  }
+
+  let nativeEtherSwap: SwapNativeEther;
+
+  if (swapOfferToAccept) {
+    nativeEtherSwap = {
+      recipient: swapOfferToAccept.recipient,
+      value: swapOfferToAccept.value,
+    };
   }
 
   const HorizontalVariant = () => {
@@ -124,6 +135,48 @@ export const CreateTokenOfferMarketplace = ({
     );
   };
 
+  const VerticalVariantSwapNativeEther = () => {
+    return (
+      <div className="flex flex-col rounded-lg flex-grow dark:!bg-red-500">
+        <div className="flex flex-col relative gap-2 flex-grow">
+          <div className="p-4 relative flex flex-grow border border-[#353836] rounded-lg dark:bg-[#282B29]">
+            <CardOffersMarketplace
+              swapModalAction={swapModalAction}
+              address={
+                swapModalAction === SwapModalAction.CREATE_SWAP
+                  ? authenticatedUserAddress
+                  : (swapOfferToAccept as PopulatedSwapOfferCard).askerTokens
+                      .address
+              }
+              variant={CreateTokenOfferVariant.VerticalVariantSwapNativeEther}
+              nativeEther={nativeEtherSwap}
+            />
+          </div>
+
+          <div className="w-full relative">
+            <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 border dark:border-[#353836] border-[#707572] bg-[#F6F6F6] dark:bg-[#212322] rounded-full w-9 h-9 flex items-center justify-center">
+              <SwapIcon variant={SwapIconVariant.VERTICAL} />
+            </div>
+          </div>
+
+          <div className="p-4 flex flex-grow border border-[#353836] rounded-lg dark:bg-[#282B29]">
+            <CardOffersMarketplace
+              swapModalAction={swapModalAction}
+              address={
+                swapModalAction === SwapModalAction.CREATE_SWAP
+                  ? validatedAddressToSwap
+                  : (swapOfferToAccept as PopulatedSwapOfferCard).bidderTokens
+                      .address
+              }
+              variant={CreateTokenOfferVariant.VerticalVariantSwapNativeEther}
+              nativeEther={nativeEtherSwap}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   const CreateTokenOfferPropsConfig: Record<
     CreateTokenOfferVariant,
     CreateTokenOfferConfig
@@ -133,6 +186,9 @@ export const CreateTokenOfferMarketplace = ({
     },
     [CreateTokenOfferVariant.VERTICAL]: {
       body: <VerticalVariant />,
+    },
+    [CreateTokenOfferVariant.VerticalVariantSwapNativeEther]: {
+      body: <VerticalVariantSwapNativeEther />,
     },
   };
 

--- a/components/03-organisms/SwapOffers.tsx
+++ b/components/03-organisms/SwapOffers.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/01-atoms";
 import { PageData, PopulatedSwapOfferCard } from "@/lib/client/offers-utils";
 import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
+import { SwapNativeEther } from "@/lib/client/swap-utils";
 import { useContext, useEffect, useState } from "react";
 import { useInView } from "react-intersection-observer";
 
@@ -102,6 +103,11 @@ export const SwapOffers = () => {
 };
 
 const SwapOffer = ({ swap }: { swap: PopulatedSwapOfferCard }) => {
+  const nativeEtherSwap: SwapNativeEther = {
+    recipient: swap.recipient,
+    value: swap.value,
+  };
+
   return (
     <div className="flex flex-col no-scrollbar border border-solid border-[#D6D5D5] dark:border-[#353836] dark:shadow-swap-station shadow-swap-station-light dark:bg-[#212322] font-onest rounded-lg ">
       <div className="flex flex-row border-b mb-auto dark:border-[#353836] relative">
@@ -109,11 +115,13 @@ const SwapOffer = ({ swap }: { swap: PopulatedSwapOfferCard }) => {
           <SwapOfferCard
             tokens={swap.askerTokens.tokens}
             address={swap.bidderTokens.address} // Should be inversed to display different in the UI
+            nativeEther={nativeEtherSwap}
           />
         </div>
         <SwapOfferCard
           tokens={swap.bidderTokens.tokens}
           address={swap.askerTokens.address} // Should be inversed to display different in the UI
+          nativeEther={nativeEtherSwap}
         />
         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 border border-[#70757230] bg-[#f6f6f6] dark:bg-[#212322] rounded-[100px] w-[24px] h-[24px] items-center flex justify-center">
           <SwapIcon />

--- a/components/03-organisms/SwapOffers.tsx
+++ b/components/03-organisms/SwapOffers.tsx
@@ -116,12 +116,14 @@ const SwapOffer = ({ swap }: { swap: PopulatedSwapOfferCard }) => {
             tokens={swap.askerTokens.tokens}
             address={swap.bidderTokens.address} // Should be inversed to display different in the UI
             nativeEther={nativeEtherSwap}
+            swap={swap}
           />
         </div>
         <SwapOfferCard
           tokens={swap.bidderTokens.tokens}
           address={swap.askerTokens.address} // Should be inversed to display different in the UI
           nativeEther={nativeEtherSwap}
+          swap={swap}
         />
         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 border border-[#70757230] bg-[#f6f6f6] dark:bg-[#212322] rounded-[100px] w-[24px] h-[24px] items-center flex justify-center">
           <SwapIcon />

--- a/components/03-organisms/SwapOffers.tsx
+++ b/components/03-organisms/SwapOffers.tsx
@@ -104,8 +104,8 @@ export const SwapOffers = () => {
 
 const SwapOffer = ({ swap }: { swap: PopulatedSwapOfferCard }) => {
   const nativeEtherSwap: SwapNativeEther = {
-    recipient: swap.recipient,
-    value: swap.value,
+    recipient: BigInt(swap.recipient),
+    value: BigInt(swap.value),
   };
 
   return (

--- a/components/03-organisms/SwapOffersMarketplace.tsx
+++ b/components/03-organisms/SwapOffersMarketplace.tsx
@@ -22,9 +22,9 @@ import {
 import { useAuthenticatedUser } from "@/lib/client/hooks/useAuthenticatedUser";
 import { getSwap } from "@/lib/service/getSwap";
 import { OffersContextMarketplace } from "@/lib/client/contexts/OffersContextMarketplace";
+import { SwapNativeEther } from "@/lib/client/swap-utils";
 import { useContext, useEffect, useState } from "react";
 import { useNetwork } from "wagmi";
-import cc from "classcat";
 
 /**
  * The horizonalVariant from TokenOffers get the data from Ponder
@@ -89,13 +89,12 @@ export const SwapOffersMarketplace = () => {
             const swapExpiryData = await decodeConfig({
               config: swapData.config,
             });
-
             return {
               id: BigInt(swap.id),
               status: swapStatus,
               expiryDate: swapExpiryData.expiry,
-              recipient: swap.recipient,
-              value: swap.value,
+              recipient: swapExpiryData.etherRecipient,
+              value: swapExpiryData.etherValue,
               bidderTokens: {
                 address: swap.bidderAssets.address,
                 tokens: bidedTokensWithData,
@@ -144,11 +143,6 @@ export const SwapOffersMarketplace = () => {
       {tokensList.map((swap, index) => {
         return <SwapOffer key={index} swap={swap} />;
       })}
-      {/* {hasNextPage && (
-          <button onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
-            {isFetchingNextPage ? "Loading..." : "Load More"}
-          </button>
-        )} */}
       <div className="flex justify-end mt-5">
         <button
           className="p-medium-bold-variant-black bg-[#DDF23D] border rounded-[10px] py-2 px-4 h-[38px] dark:border-[#181a19] border-white"
@@ -169,23 +163,25 @@ export const SwapOffersMarketplace = () => {
   );
 };
 
-interface SwapOfferProps {
-  swap: PopulatedSwapOfferCard;
-}
-
-const SwapOffer = ({ swap }: SwapOfferProps) => {
+const SwapOffer = ({ swap }: { swap: PopulatedSwapOfferCard }) => {
+  const nativeEtherSwap: SwapNativeEther = {
+    recipient: swap.recipient,
+    value: swap.value,
+  };
   return (
     <div className="flex flex-col no-scrollbar border border-solid border-[#D6D5D5] dark:border-[#353836] dark:shadow-swap-station shadow-swap-station-light dark:bg-[#212322] font-onest rounded-lg ">
       <div className="flex flex-row border-b mb-auto dark:border-[#353836] relative">
-        <div className={cc(["border-r dark:border-[#353836]"])}>
+        <div className="border-r dark:border-[#353836]">
           <SwapOfferCardMarketplace
             tokens={swap.askerTokens.tokens}
             address={swap.askerTokens.address}
+            nativeEther={nativeEtherSwap}
           />
         </div>
         <SwapOfferCardMarketplace
           tokens={swap.bidderTokens.tokens}
           address={swap.bidderTokens.address}
+          nativeEther={nativeEtherSwap}
         />
         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 border border-[#70757230] bg-[#f6f6f6] dark:bg-[#212322] rounded-[100px] w-[24px] h-[24px] items-center flex justify-center">
           <SwapIcon />

--- a/lib/client/swap-utils.ts
+++ b/lib/client/swap-utils.ts
@@ -31,6 +31,11 @@ export type TokenWithSwapInfo = {
   amountOrId: bigint;
 };
 
+export interface SwapNativeEther {
+  recipient: bigint;
+  value: bigint;
+}
+
 export interface IApproveTokenSwap {
   walletClient: WalletClient;
   tokenContractAddress: `0x${string}`;
@@ -39,14 +44,6 @@ export interface IApproveTokenSwap {
   chainId: number;
   token: Token;
   onWalletConfirmation: () => void;
-}
-
-export enum TimeStampDate {
-  ONE_DAY = 24 * 60 * 60 * 1000,
-  ONE_WEEK = ONE_DAY * 7,
-  ONE_MONTH = ONE_WEEK * 4,
-  SIX_MONTH = ONE_MONTH * 6,
-  ONE_YEAR = SIX_MONTH * 2,
 }
 
 export function getTokenInfoBeforeSwap(token: Token): TokenWithSwapInfo {

--- a/lib/client/ui-utils.ts
+++ b/lib/client/ui-utils.ts
@@ -1,4 +1,3 @@
-import { TimeStampDate } from "./swap-utils";
 import {
   ERC20,
   ERC20WithTokenAmountSelection,
@@ -12,24 +11,12 @@ export const WIDE_SCREEN_SIZE = 1279;
 export const DESKTOP_SCREEN_SIZE = 1023;
 export const TABLET_SCREEN_SIZE = 768;
 
-export interface ExpireOption {
-  label: string;
-  value: TimeStampDate;
-}
-
 export enum SwapModalSteps {
   APPROVE_TOKENS,
   ACCEPT_SWAP,
   WAIT_BLOCKCHAIN_INTERACTION,
   SUCCESSFUL_SWAP,
 }
-
-export const ExpireDate: ExpireOption[] = [
-  { label: "1 day", value: TimeStampDate.ONE_DAY },
-  { label: "1 week", value: TimeStampDate.ONE_WEEK },
-  { label: "1 month", value: TimeStampDate.ONE_MONTH },
-  { label: "1 year", value: TimeStampDate.ONE_YEAR },
-];
 
 export const getTokenName = (
   token: Token,


### PR DESCRIPTION
Closes #394 
- [x] remove ether-field-addition when the user wallet is not connected
- [x] Display the native ether of the swap in Preview modal ( Accept modal, Create Swap Modal )
- [x] Display the native ether amount of the swap In offers pages SwapOfferCards
- [x] Display the native ether amount of the swap In marketplace pages SwapOfferCards